### PR TITLE
Feature/46 할 일 목록 날짜 별 할 일 목록 수정 시 UI 구현하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import 'react-day-picker/dist/style.css';
 import './styles/customPickerStyle.css';
+import { ETIndexed } from './DB/indexed';
 
 const queryClient = new QueryClient();
 

--- a/src/hooks/useEdit.tsx
+++ b/src/hooks/useEdit.tsx
@@ -5,16 +5,28 @@ interface IEdit {
   editMode: boolean;
   editTodoId: number | undefined;
 }
-type contextType = [IEdit, React.Dispatch<React.SetStateAction<IEdit>>];
+type editContextType = [IEdit, (newEditState: IEdit) => void];
+const defaultUseEdit: editContextType = [
+  { editMode: false, editTodoId: undefined },
+  (newEditState: IEdit) => {},
+];
 
-// interface IEditContextProps extends IChildProps {}
-
-const EditContext = createContext<contextType | undefined>(undefined);
+const EditContext = createContext<editContextType>(defaultUseEdit);
 
 const EditContextProvider = ({ children }: IChildProps): JSX.Element => {
-  const editState = useState<IEdit>({ editMode: false, editTodoId: undefined });
+  const [edit, setEdit] = useState<IEdit>({
+    editMode: false,
+    editTodoId: undefined,
+  });
+
+  const handleState = (newEditState: IEdit) => {
+    setEdit(newEditState);
+  };
+
+  const wrapState: editContextType = [edit, handleState];
+
   return (
-    <EditContext.Provider value={editState}>{children}</EditContext.Provider>
+    <EditContext.Provider value={wrapState}>{children}</EditContext.Provider>
   );
 };
 
@@ -27,4 +39,4 @@ const useEdit = () => {
   return value;
 };
 
-export { useEdit, EditContextProvider };
+export { useEdit, EditContextProvider, type IEdit, type editContextType };

--- a/src/molecules/TodoCard/content/DayPickerUI.tsx
+++ b/src/molecules/TodoCard/content/DayPickerUI.tsx
@@ -64,11 +64,12 @@ const DayPickerUI = ({
             <DayPicker
               initialFocus={showPopper}
               mode="single"
-              defaultMonth={selected}
               selected={selected}
               onSelect={handleDaySelect}
+              defaultMonth={new Date()}
+              fromMonth={new Date()}
+              disabled={{ before: new Date() }}
               required
-              hidden={isPastDate}
             />
           </div>
         </FocusTrap>

--- a/src/shared/queries.ts
+++ b/src/shared/queries.ts
@@ -4,7 +4,7 @@ import { ETIndexed } from '../DB/indexed';
 
 // ordering
 const useOrderingMutation = () => {
-  const db = new ETIndexed();
+  const db = ETIndexed.getInstance();
   const queryClient = useQueryClient();
   const mutationHandler = async ({
     prevOrder,


### PR DESCRIPTION
- day picker를 조금 더 자연스럽게 하기 위해서, 지난 날짜를 hidden을 통해서 선택하지 못하는 것이 아니라 보이되 선택되지 않게 바꾸었습니다. 그리고 이전 달로 이동도 막았습니다.