### PR TITLE
Feature/85 indexeddb에 utc 작업하기

### DIFF
--- a/src/DB/indexed.ts
+++ b/src/DB/indexed.ts
@@ -78,7 +78,10 @@ class ETIndexed {
           getOrdered.slice(Number(searchDate.order)),
         ) as TodoEntity[];
       }
-      await Promise.all(plusedTodo.map((todo) => this.action.updateOne(todo)));
+      plusedTodo &&
+        (await Promise.all(
+          plusedTodo.map((todo) => this.action.updateOne(todo)),
+        ));
     }
 
     const newTodo = {
@@ -173,13 +176,13 @@ class ETIndexed {
     await this.action.updateOne(getTodo);
   }
 
-  async getList(isDone: boolean): Promise<Map<string, TodoEntity[]>> {
+  async getList(isDone: boolean): Promise<TodoEntity[]> {
     await this.action.waitForInit();
     const getTodos = await this.action.getAll();
-    if (getTodos.length === 0) return new Map();
+    if (getTodos.length === 0) return [];
     const doneTodo = getTodos.filter((todo) => todo.done === isDone);
     const orderedTodo = this.calc.orderedList(doneTodo);
-    return this.calc.groupByDate(orderedTodo);
+    return orderedTodo;
   }
 }
 

--- a/src/DB/indexed.ts
+++ b/src/DB/indexed.ts
@@ -147,6 +147,9 @@ class ETIndexed {
   }
 
   async updateTodo(id: number, todo: UpdateTodoDto) {
+    if (Array.isArray(todo.categories) && todo.categories.length > 5) {
+      return alert('카테고리는 5개 까지 추가할 수 있습니다.');
+    }
     const getTodo = await this.action.getOne(id);
     Object.assign(getTodo, todo);
     const updated = await this.action.updateOne(getTodo);

--- a/src/DB/indexedCalc.ts
+++ b/src/DB/indexedCalc.ts
@@ -9,17 +9,6 @@ class ETIndexedDBCalc {
     return todoList.sort((a, b) => (a.order as number) - (b.order as number));
   }
 
-  // QUESTION : date 타입을 string으로 해도.. 문제가 없겠지?.. 나중에 nest 서버랑 같이 쓴다고 했을 때도 문제가 없겠지?..
-  groupByDate(todoList: TodoEntity[]): Map<string, TodoEntity[]> {
-    const mapped = new Map<string, TodoEntity[]>();
-    for (const todo of todoList) {
-      const index = mapped.get(todo.date) || [];
-      index.push(todo);
-      mapped.set(todo.date, index);
-    }
-    return mapped;
-  }
-
   updateOrder(
     todoList: TodoEntity[],
     prevOrder: number,

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -27,36 +27,36 @@ import {
 /* etc */
 import { todosApi } from '../shared/apis';
 import styled from '@emotion/styled';
-import { setTimeInFormat } from '../shared/timeUtils';
+import { groupByDate, setTimeInFormat } from '../shared/timeUtils';
 
 const addTodoMocks = (): AddTodoDto[] => {
   return [
     {
-      date: '2023-10-30',
+      date: '2024-06-11T15:00:00',
       todo: 'practice valorant',
       duration: 1,
       categories: ['game', 'practice'],
     },
     {
-      date: '2023-10-30',
+      date: '2024-06-16T15:00:00',
       todo: 'go to grocery store',
       duration: 2,
       categories: ['chore'],
     },
     {
-      date: '2023-10-29',
+      date: '2024-06-11T15:00:00',
       todo: 'Watch English News',
       duration: 1,
       categories: ['english', 'study'],
     },
     {
-      date: '2023-10-29',
+      date: '2024-06-16T15:00:00',
       todo: 'Start Exercise',
       duration: 1,
       categories: ['health'],
     },
     {
-      date: '2023-10-27',
+      date: '2024-06-20T15:00:00',
       todo: 'check riff',
       duration: 0.05,
       categories: [
@@ -68,7 +68,7 @@ const addTodoMocks = (): AddTodoDto[] => {
       ],
     },
     {
-      date: '2023-10-27',
+      date: '2024-06-21T15:00:00',
       todo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
       duration: 3,
       categories: [

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -32,31 +32,31 @@ import { groupByDate, setTimeInFormat } from '../shared/timeUtils';
 const addTodoMocks = (): AddTodoDto[] => {
   return [
     {
-      date: '2024-06-11T15:00:00',
+      date: '2024-06-11T15:00:00Z',
       todo: 'practice valorant',
       duration: 1,
       categories: ['game', 'practice'],
     },
     {
-      date: '2024-06-16T15:00:00',
+      date: '2024-06-16T15:00:00Z',
       todo: 'go to grocery store',
       duration: 2,
       categories: ['chore'],
     },
     {
-      date: '2024-06-11T15:00:00',
+      date: '2024-06-11T15:00:00Z',
       todo: 'Watch English News',
       duration: 1,
       categories: ['english', 'study'],
     },
     {
-      date: '2024-06-16T15:00:00',
+      date: '2024-06-16T15:00:00Z',
       todo: 'Start Exercise',
       duration: 1,
       categories: ['health'],
     },
     {
-      date: '2024-06-20T15:00:00',
+      date: '2024-06-20T15:00:00Z',
       todo: 'check riff',
       duration: 0.05,
       categories: [
@@ -68,7 +68,7 @@ const addTodoMocks = (): AddTodoDto[] => {
       ],
     },
     {
-      date: '2024-06-21T15:00:00',
+      date: '2024-06-21T15:00:00Z',
       todo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
       duration: 3,
       categories: [

--- a/src/test/DB/indexedCalc.spec.ts
+++ b/src/test/DB/indexedCalc.spec.ts
@@ -25,14 +25,6 @@ describe('ExtremeTodoIndexedDB', () => {
     });
   });
 
-  describe('groupByDate', () => {
-    it('date를 기준으로 todo를 묶는다.', () => {
-      const grouped = indexedCalc.groupByDate(mockTodoList);
-      expect(grouped instanceof Map).toBe(true);
-      expect(grouped.size).toBe(4);
-    });
-  });
-
   describe('updateOrder', () => {
     let correspondingOrder: typeof mockTodoList;
 


### PR DESCRIPTION
- 다른 부분은 백엔드와 다르지 않았고 groupByDate를 제거하는 부분을 동기화 하였습니다.
- indexedDB로 연결해서 addTodo, reroderTodos, updateTodo 다 해보았는데 잘 됩니다 :) 테스트 코드도 문제 없었습니다.

- 작은 문제가 생겼는데, 예전 nest서버와 마찬가지로 indexedDB에서도 getList를 할 때 groupByDate가 적용된 return 값이 주어져서 후처리를 따로 하지 않고 사용가능 했습니다. 하지만 이를 제거함으로 인해서 프론트단에 만들어 둔 groupByDate를 적용하기가 아직은 불편합니다. nest는 api 객체에서 받아온 todo배열을 groupByDate로 적용하면 되는데 아직 IndexedDB는 api 객체가 따로 없기 때문에 테스트를 위해 몇 줄 더 추가해야 합니다 ㅋㅋ

```ts
const { data: todos, isLoading } = useQuery(
    ['todos'],
    // () => todosApi.getList(false),
    () => {
      const temp = async () => {
        const result = await ETIndexed.getInstance().getList(false);
        return groupByDate(result);
      };
      return temp();
    },
    {
      refetchOnWindowFocus: false,
    },
  );
```
- 위 코드는 getList를 하는 부분인데 이전에는 주석처리된 `todosApi.getList`처럼 간단하게 `ETIndexed.getInstance().getList(false)`하면 됐는데 이젠 저렇게 해서 groupByDate를 해줘야 합니다 ㅋㅋ
- 이 작업을 하면서 일단 계속 ETIndexed에 대한 작업을 해나가지만 모듈은 배포 후 차차 구축해도 되지 않을까 하는 생각을 했습니다. 일전에도 이에 대한 이야기를 나누었는지 기억이 잘 안 나지만, PWA버전에서 사용할 거니까 당장은 필요 없을 거 같아서요. 그래서 희정님 IndexedDB나 오프라인 환경에 대한 작업을 목록화만 잘 해두시고 후순위로 미루셔도 되지 않을까 하는 생각이 들었습니다 ㅋㅋ 다음 미팅 때 이 이야기도 나누면 좋겠네요 :)