### PR TITLE
Feature/89 todo module 만들기

### DIFF
--- a/src/DB/indexed.ts
+++ b/src/DB/indexed.ts
@@ -9,6 +9,8 @@
 import { ETIndexedDBAction } from './indexedAction';
 import { ETIndexedDBCalc } from './indexedCalc';
 import type { TodoEntity } from './indexedAction';
+import { groupByDate } from '../shared/timeUtils';
+import { TodoModuleType } from '../shared/todoModule';
 
 /* 
 removeTodos <- Cron 사용한 메소드임 -> 로그인이 안됐다? useEffect() 안에서 ETIndexedDBAction 이용해서 지금 DB 안에 있는 거 중에.. 어제꺼 Todo 쓰윽 지워버리던지..
@@ -32,7 +34,7 @@ type UpdateTodoDto = Partial<
   Pick<TodoEntity, 'duration' | 'todo' | 'categories' | 'date'>
 >;
 
-class ETIndexed {
+class ETIndexed implements TodoModuleType {
   private static instance: ETIndexed;
 
   private constructor(
@@ -96,7 +98,6 @@ class ETIndexed {
   }
 
   async reorderTodos(prevOrder: number, newOrder: number) {
-    console.log(prevOrder, newOrder);
     const allTodoList = await this.action.getAll();
     const notNullTodos = allTodoList.filter((todo) => todo.order !== null);
     let bigNumber = 0,
@@ -176,13 +177,17 @@ class ETIndexed {
     await this.action.updateOne(getTodo);
   }
 
-  async getList(isDone: boolean): Promise<TodoEntity[]> {
+  async getList(isDone: boolean) {
     await this.action.waitForInit();
     const getTodos = await this.action.getAll();
-    if (getTodos.length === 0) return [];
+    if (getTodos.length === 0) return new Map();
     const doneTodo = getTodos.filter((todo) => todo.done === isDone);
     const orderedTodo = this.calc.orderedList(doneTodo);
-    return orderedTodo;
+    return groupByDate(orderedTodo);
+  }
+
+  removeTodosBeforeToday() {
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/DB/indexed.ts
+++ b/src/DB/indexed.ts
@@ -197,9 +197,7 @@ class ETIndexed implements TodoModuleType {
     await this.action.waitForInit();
     const getTodos = await this.action.getAll();
     if (getTodos.length === 0) return;
-    const stailTodos = getTodos.filter(
-      (todo) => new Date(todo.date) <= new Date(currentDate),
-    );
+    const stailTodos = getTodos.filter((todo) => todo.date <= currentDate);
     await Promise.all(
       stailTodos.map((todo) => this.action.removeOne(todo.todo)),
     );

--- a/src/DB/indexed.ts
+++ b/src/DB/indexed.ts
@@ -11,7 +11,6 @@ import { ETIndexedDBCalc } from './indexedCalc';
 import type { TodoEntity } from './indexedAction';
 import { groupByDate } from '../shared/timeUtils';
 import { TodoModuleType } from '../shared/todoModule';
-import { format } from 'date-fns';
 
 /* 
 removeTodos <- Cron 사용한 메소드임 -> 로그인이 안됐다? useEffect() 안에서 ETIndexedDBAction 이용해서 지금 DB 안에 있는 거 중에.. 어제꺼 Todo 쓰윽 지워버리던지..
@@ -188,18 +187,19 @@ class ETIndexed implements TodoModuleType {
   }
 
   /**
+   * timeUtils에 있는 setTimeInFormat를 사용해서 해당 날짜 05:00:00를 기준으로 toISOString()메소드를 호출해야 한다.
+   * cf) removeTodosBeforeToday(setTimeInFormat(new Date(), '05:00:00').toISOString())
+   * @param {string} currentDate UTC형식의 시간입니다. toISOString 메소드를 사용한 결과
    *
-   * @param {string} currentDate UTC형식의 시간입니다. toISOString 메소드를 사용한 결과입니다.
    * @returns
    */
   async removeTodosBeforeToday(currentDate: string) {
     await this.action.waitForInit();
     const getTodos = await this.action.getAll();
     if (getTodos.length === 0) return;
-    const stailTodos = getTodos.filter((todo) => {
-      const pivotTime = format(new Date(currentDate), 'y-MM-dd');
-      return new Date(todo.date) <= new Date(`${pivotTime} 05:00:00`);
-    });
+    const stailTodos = getTodos.filter(
+      (todo) => new Date(todo.date) <= new Date(currentDate),
+    );
     await Promise.all(
       stailTodos.map((todo) => this.action.removeOne(todo.todo)),
     );

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -39,7 +39,7 @@ const Setting = () => {
   const handleReset = () => {
     if (confirm('정말로 기록을 초기화 하시겠습니까?')) {
       Promise.all([
-        todosApi.reset(),
+        todosApi.resetTodos(),
         rankingApi.resetRanking(),
         timerApi.reset(),
       ]).then(() => window.alert('초기화 성공'));

--- a/src/shared/apis.ts
+++ b/src/shared/apis.ts
@@ -142,7 +142,7 @@ export const todosApi: TodoModuleType = {
     });
   },
   async removeTodosBeforeToday(currentDate: string) {
-    // return await baseApi.delete('/todos', { params: { currentDate } });
+    return await baseApi.delete('/todos', { params: { currentDate } });
   },
 };
 

--- a/src/shared/apis.ts
+++ b/src/shared/apis.ts
@@ -86,7 +86,7 @@ export const todosApi = {
   getCategories: async () => {
     return baseApi.get('categories');
   },
-  async reset() {
+  async resetTodos() {
     await baseApi.delete('todos/reset');
   },
   async addTodo(todo: AddTodoDto) {

--- a/src/shared/timeUtils.ts
+++ b/src/shared/timeUtils.ts
@@ -1,6 +1,8 @@
 import { format } from 'date-fns';
 import { TodoEntity } from '../DB/indexedAction';
 
+type FormatTimeType = `${number}:${number}:${number}`;
+
 /**
  * 분을 입력하면 일,시간,분으로 변환해주는 포매터
  * @param time min ex) 720
@@ -36,8 +38,11 @@ export const formatTime = (time: number): string => {
  * @param date
  * @returns
  */
-export const setTimeInFormat = (date: Date) => {
-  return new Date(`${getDateInFormat(date)} 00:00:00`);
+export const setTimeInFormat = (
+  date: Date,
+  time: FormatTimeType = '00:00:00',
+) => {
+  return new Date(`${getDateInFormat(date)} ${time}`);
 };
 
 /**

--- a/src/shared/todoModule.ts
+++ b/src/shared/todoModule.ts
@@ -1,0 +1,67 @@
+import { AddTodoDto, ETIndexed, UpdateTodoDto } from '../DB/indexed';
+import { TodoEntity } from '../DB/indexedAction';
+import { todosApi } from './apis';
+
+type ModuleType = typeof todosApi | ETIndexed;
+
+export interface TodoModuleType {
+  resetTodos(): Promise<void>;
+  addTodo(todo: AddTodoDto): any;
+  reorderTodos(prevOrder: number, newOrder: number): any;
+  updateTodo(id: number, todo: UpdateTodoDto): any;
+  getList(isDone: boolean): Promise<Map<string, TodoEntity[]>>;
+  getOneTodo(id: number): Promise<TodoEntity>;
+  deleteTodo(id: number): any;
+  doTodo(id: number, focusTime: string): any;
+  removeTodosBeforeToday(currentDate: string): any;
+}
+
+export class TodoModule implements TodoModuleType {
+  private static instance: TodoModule;
+  private api: ModuleType;
+
+  private constructor(api: ModuleType) {
+    this.api = api;
+  }
+
+  static getInstance(api: ModuleType): TodoModule {
+    if (!this.instance) {
+      TodoModule.instance = new TodoModule(api);
+      return TodoModule.instance;
+    }
+    return TodoModule.instance;
+  }
+
+  resetTodos(): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+  addTodo(todo: AddTodoDto) {
+    throw new Error('Method not implemented.');
+  }
+  reorderTodos(prevOrder: number, newOrder: number) {
+    throw new Error('Method not implemented.');
+  }
+  updateTodo(
+    id: number,
+    todo: Partial<
+      Pick<TodoEntity, 'date' | 'todo' | 'duration' | 'categories'>
+    >,
+  ): Promise<TodoEntity> {
+    throw new Error('Method not implemented.');
+  }
+  getList(isDone: boolean): Promise<Map<string, TodoEntity[]>> {
+    throw new Error('Method not implemented.');
+  }
+  getOneTodo(id: number): Promise<TodoEntity> {
+    throw new Error('Method not implemented.');
+  }
+  deleteTodo(id: number) {
+    throw new Error('Method not implemented.');
+  }
+  doTodo(id: number, focusTime: string) {
+    throw new Error('Method not implemented.');
+  }
+  removeTodosBeforeToday() {
+    throw new Error('Method not implemented.');
+  }
+}


### PR DESCRIPTION
- 당장 필요한 부분인 removeTodosBeforeToday를 추가하였습니다.
- 추가적으로 필요한 작업이 남아있습니다. 그래서 일단 말씀드린대로 당장 필요한 부분인, removeTodosBeforeToday메소드를 추가한 부분만 PR올립니다.
- 그 외에 작업으로는 todoModule 세부 코드 작성하는 것, todo 데이터의 id값 바꾸는 것 정도 있을 것 같습니다.
- 배포 후에 DB에 대한 수정을 하면 에러가 생길 것 같아서 id값을 바꾸는 것을 nest는 현재 하고 있는 토큰 재발급 작업 이후 우선적으로 빠르게 작업을 하도록 하겠습니다.

## 변경사항
- 함께 라이브 코딩으로 indexedDB에 removeTodosBeforeToday를 추가하였지만, PR을 위해서 갈무리 하다 보니 자잘한 문제가 눈에 보여서 조금 수정했습니다.
- 그때 removeTodosBeforeToday을 작업할 때 먼저, UTC 처리된 시간을 받아서 거기서 날짜만 date-fns을 사용해서 떼어낸 뒤, 그 날짜에 05:00:00를 붙여주었습니다. 하지만 문제는 백엔드는 이렇게 작업이 되고 있지 않다는 것이고, 백엔드에서는 이렇게 작업을 하는 것이 괜찮을까를 생각해 보았을 때 아닐 것 같아 보였습니다.
- 저희가 백엔드의 시간대를 UTC 표준시로 설정을 해두었는데, 사용자가 요청을 보내는 시간대의 05:00를 기준으로 UTC 처리를 해서 백엔드로 줘야 하는데, 지금 형태는 백엔드에서 UTC날짜에 05:00를 무조건적으로 적용하는 형태입니다. 즉 사용자의 시간대를 기준으로 05:00가 아니라 백엔드 시간대를 기준으로 05:00를 적용하는 거라 문제가 될 거 같습니다.
- 그래서 이 부분을 해결하기 위해 애초에 removeTodosBeforeToday에 인자로 시간을 넘겨줄 때 해당 날짜 05:00시로 시간을 정하는 것으로 코드를 수정하였습니다.
- 더불어 이미 만들어 두었던 timeUtils 파일 안에 공용 함수를 활용하였습니다.

확인하시고 제가 놓친 부분이나 개선할 부분이 있다면 코멘트 남겨주세요 :)