### PR TITLE
Fix/168 usepomodoro에 rxjs 도입하여 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extreme-frontend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extreme-frontend",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
@@ -34,10 +34,12 @@
         "react-router-dom": "^6.4.1",
         "react-scripts": "^5.0.1",
         "react-swipeable": "^7.0.1",
+        "rxjs": "^7.8.1",
         "typescript": "^4.4.2",
         "web-vitals": "^2.1.0"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/puppeteer": "^7.0.4",
         "@types/react-beautiful-dnd": "^13.1.4",
         "eslint": "^8.36.0",
@@ -3899,7 +3901,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3927,6 +3928,56 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@remix-run/router": {
       "version": "1.18.0",
@@ -4693,6 +4744,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -5160,6 +5217,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -5663,19 +5730,6 @@
         "node": ">=8.9"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6047,6 +6101,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -6153,6 +6219,12 @@
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -6518,6 +6590,81 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.3.tgz",
+      "integrity": "sha512-7RYKL+vZVCyAsMLi5SPu7QGauGGT8avnP/HO571ndEuV4MYdGXvLhtW67FuLPeEI8EiIY7zbbRR9x7x7HU0kgw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
+      "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.0.tgz",
+      "integrity": "sha512-+o9MG5bPRRBlkVSpfFlMag3n7wMaIZb4YZasU2+/96f+3HTQ4F9DKQeu3K/Sjz1W0umu6xvVq1ON0ipWdMlr3A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.18.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -6710,6 +6857,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -7825,6 +8005,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -7891,10 +8080,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
-      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
-      "peer": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8040,14 +8228,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -8146,6 +8326,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1349977",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1349977.tgz",
+      "integrity": "sha512-5JcwlDKinshGSm+4AVLFCkokJUAKTgjmiorNmrGgYYKix1h8Ts9/fplQeK1xg/rACYw1JlEM2PwIEvny5QswKQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8397,6 +8584,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
@@ -8417,6 +8613,15 @@
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -9687,6 +9892,41 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9699,6 +9939,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -9774,6 +10020,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10284,21 +10539,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/fs-monkey": {
@@ -11003,20 +11243,6 @@
         }
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -11067,6 +11293,26 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -14742,6 +14988,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -15396,6 +15648,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -15489,6 +15749,15 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -15936,6 +16205,11 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -16070,6 +16344,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -17640,6 +17920,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -17765,6 +18054,16 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -17829,6 +18128,12 @@
         }
       }
     },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1299070",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1299070.tgz",
+      "integrity": "sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg==",
+      "dev": true
+    },
     "node_modules/puppeteer/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -17862,6 +18167,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1299070",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1299070.tgz",
+      "integrity": "sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg==",
+      "dev": true
     },
     "node_modules/puppeteer/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -17951,17 +18262,6 @@
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -20297,6 +20597,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -20767,6 +21075,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -20922,13 +21240,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -21082,6 +21393,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
+      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -22020,6 +22345,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -22052,6 +22386,12 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==",
       "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -22376,6 +22716,11 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -22510,6 +22855,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
     },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
@@ -23601,6 +23952,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -23611,6 +23972,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.4.1",
     "react-scripts": "^5.0.1",
     "react-swipeable": "^7.0.1",
+    "rxjs": "^7.8.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/src/components/MainTodo.tsx
+++ b/src/components/MainTodo.tsx
@@ -10,30 +10,29 @@ import { usePomodoroActions, usePomodoroValue, useTimeMarker } from '../hooks';
 import { getPomodoroStepPercent } from '../shared/timeUtils';
 import AddTodo from './AddTodo';
 import PomodoroTimeSetting from './PomodoroTimeSetting';
+import { PomodoroStatus } from '../services/PomodoroService';
 
 type ModalType = 'todolistModal' | 'addTodoModal' | 'timeModal';
 
 function MainTodo() {
   const [isModal, setIsModal] = useState<ModalType | null>(null);
 
-  const { status: pomodoroStatus, settings: pomodoroSettings } =
-    usePomodoroValue();
-  const { startResting } = usePomodoroActions();
+  const {
+    status: pomodoroStatus,
+    settings: pomodoroSettings,
+    time: pomodoroTime,
+  } = usePomodoroValue();
   const [focusedPercent, setFocusedPercent] = useState<number>(0);
   const [restedPercent, setRestedPercent] = useState<number>(0);
   const mainTodoRef = useRef<HTMLDivElement>(null);
   useTimeMarker();
 
   useEffect(() => {
-    // 최초 진입시에는 휴식 상태로 시작
-    startResting();
-  }, []);
-
-  useEffect(() => {
     setFocusedPercent(
       Number(
         getPomodoroStepPercent({
-          curr: pomodoroStatus.focusedTime,
+          curr:
+            pomodoroStatus === PomodoroStatus.FOCUSING ? pomodoroTime ?? 0 : 0,
           unit: 1,
           step: pomodoroSettings.focusStep,
         }),
@@ -42,13 +41,14 @@ function MainTodo() {
     setRestedPercent(
       Number(
         getPomodoroStepPercent({
-          curr: pomodoroStatus.restedTime,
+          curr:
+            pomodoroStatus === PomodoroStatus.RESTING ? pomodoroTime ?? 0 : 0,
           unit: 1,
           step: pomodoroSettings.restStep,
         }),
       ),
     );
-  }, [pomodoroStatus]);
+  }, [pomodoroTime]);
 
   return (
     <MainTodoContainer ref={mainTodoRef}>

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TodoEntity } from '../DB/indexedAction';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { timerApi, todosApi } from '../shared/apis';
@@ -102,13 +102,24 @@ const useCurrentTodo = () => {
     }
   };
 
-  return {
-    doTodo,
-    updateFocus,
-    currentTodo,
-    focusedOnTodo,
-    checkLocalStorageAndGetFocusTime,
-  };
+  const useCurrentTodoResult = useMemo(
+    () => ({
+      doTodo,
+      updateFocus,
+      currentTodo,
+      focusedOnTodo,
+      checkLocalStorageAndGetFocusTime,
+    }),
+    [
+      doTodo,
+      updateFocus,
+      currentTodo,
+      focusedOnTodo,
+      checkLocalStorageAndGetFocusTime,
+    ],
+  );
+
+  return useCurrentTodoResult;
 };
 export default useCurrentTodo;
 export { type TodoResponseDto };

--- a/src/hooks/useExtremeMode.tsx
+++ b/src/hooks/useExtremeMode.tsx
@@ -87,6 +87,7 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
           setLeftTime('휴식시간 초과로 모든 기록이 초기화되었습니다.');
           pomodoroActions.stopTimer();
           queryClient.invalidateQueries(['todos']);
+          queryClient.invalidateQueries(['category']);
         })
         .catch(() => {
           setLeftTime('초기화가 실패했습니다. 운 좋은 줄 아십시오...');

--- a/src/hooks/useExtremeMode.tsx
+++ b/src/hooks/useExtremeMode.tsx
@@ -51,8 +51,6 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
 
   const getLeftTime = () => {
     if (status === PomodoroStatus.RESTING) {
-      console.log(time);
-
       const leftMs = settings.restStep * 60000 - (time ?? 0);
       const minutes = (leftMs % 3600000) / 60000;
       if (leftMs >= 0) {

--- a/src/hooks/useExtremeMode.tsx
+++ b/src/hooks/useExtremeMode.tsx
@@ -12,6 +12,8 @@ import { rankingApi, settingsApi, timerApi, todosApi } from '../shared/apis';
 import { ETIndexed } from '../DB/indexed';
 import { useIsOnline } from './useIsOnline';
 import useCurrentTodo from './useCurrentTodo';
+import { PomodoroStatus } from '../services/PomodoroService';
+import { useQueryClient } from '@tanstack/react-query';
 
 export interface IExtremeMode {
   isExtreme: boolean;
@@ -26,14 +28,16 @@ export const ExtremeModeContext = createContext<IExtremeMode>(
 );
 
 export const ExtremeModeProvider = ({ children }: IChildProps) => {
-  const { status, settings } = usePomodoroValue();
+  const { status, settings, time } = usePomodoroValue();
   const pomodoroActions = usePomodoroActions();
   const { currentTodo } = useCurrentTodo();
   const [resetFlag, setResetFlag] = useState<boolean>(false); // true 면 reset 완료
-  const prevStatus = useRef(status.isResting);
+  const prevStatus = useRef(status);
   const isOnline = useIsOnline();
+  const queryClient = useQueryClient();
+
   const setMode = (newMode: boolean) => {
-    if (status.isFocusing === true) {
+    if (status === PomodoroStatus.FOCUSING) {
       window.alert('집중 시간에는 모드 변경이 불가능합니다.');
     } else
       setExtremeMode((prev: IExtremeMode) => {
@@ -44,9 +48,12 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
       colorMode: 'auto',
     });
   };
+
   const getLeftTime = () => {
-    if (status.isResting) {
-      const leftMs = settings.restStep * 60000 - status.restedTime;
+    if (status === PomodoroStatus.RESTING) {
+      console.log(time);
+
+      const leftMs = settings.restStep * 60000 - (time ?? 0);
       const minutes = (leftMs % 3600000) / 60000;
       if (leftMs >= 0) {
         setLeftTime(
@@ -67,7 +74,7 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
     }
     if (
       extremeMode.isExtreme === true &&
-      prevStatus.current === status.isResting &&
+      prevStatus.current === status &&
       resetFlag === false &&
       currentTodo !== null &&
       Number(leftMs) < 0
@@ -80,18 +87,19 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
       )
         .then(() => {
           setLeftTime('휴식시간 초과로 모든 기록이 초기화되었습니다.');
-          pomodoroActions.setEnableTimer(false);
+          pomodoroActions.stopTimer();
+          queryClient.invalidateQueries(['todos']);
         })
         .catch(() => {
           setLeftTime('초기화가 실패했습니다. 운 좋은 줄 아십시오...');
         });
       setResetFlag(true);
     }
-    if (prevStatus.current != status.isResting) {
+    if (prevStatus.current != status) {
       setResetFlag(false);
-      prevStatus.current = status.isResting;
+      prevStatus.current = status;
     }
-  }, [status]);
+  }, [time]);
 
   const [extremeMode, setExtremeMode] = useState<IExtremeMode>({
     isExtreme: DEFAULT_IS_EXTREME,

--- a/src/hooks/usePomodoro.tsx
+++ b/src/hooks/usePomodoro.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react';
 import { IChildProps } from '../shared/interfaces';
-import { timerApi } from '../shared/apis';
+import { PomodoroService, PomodoroStatus } from '../services/PomodoroService';
 
 export const pomodoroUnit = 60000;
 // TODO : 테스트용 1 제거 필요
@@ -20,20 +20,7 @@ export const initialPomodoroData: IPomodoroData = {
     focusStep: 1,
     restStep: 1,
   },
-  status: {
-    isFocusing: false,
-    isResting: true,
-    focusedTime: 0,
-    restedTime: 0,
-  },
 };
-
-interface IPomodoroStatus {
-  isFocusing: boolean;
-  isResting: boolean;
-  focusedTime: number;
-  restedTime: number;
-}
 
 interface IPomodoroSettings {
   focusStep: focusStep;
@@ -42,15 +29,16 @@ interface IPomodoroSettings {
 
 interface IPomodoroData {
   settings: IPomodoroSettings;
-  status: IPomodoroStatus;
+  status?: PomodoroStatus;
+  time?: number;
 }
 
 interface IPomodoroActions {
-  setEnableTimer: (enable: boolean) => void;
   setFocusStep: (step: focusStep) => void;
   setRestStep: (step: restStep) => void;
   startFocusing: () => void;
   startResting: () => void;
+  stopTimer: () => void;
 }
 
 const PomodoroValueContext = createContext<IPomodoroData>({} as IPomodoroData);
@@ -62,24 +50,26 @@ const PomodoroProvider = ({ children }: IChildProps) => {
   const [settings, setSetting] = useState<IPomodoroSettings>(
     getPomodoroData<IPomodoroSettings>('settings'),
   );
-  const [status, setStatus] = useState<IPomodoroStatus>(
-    getPomodoroData<IPomodoroStatus>('status'),
-  );
-  const enableRef = useRef<boolean>(true);
-  const statusRef = useRef<IPomodoroStatus>(status);
+  const [time, setTime] = useState<number>();
+  const [status, setStatus] = useState<PomodoroStatus>();
+
   const settingsRef = useRef<IPomodoroSettings>(settings);
 
-  let interval: NodeJS.Timer;
+  useEffect(() => {
+    PomodoroService.startTimer();
+  }, []);
+
+  useEffect(() => {
+    PomodoroService.pomodoroStatus$.subscribe((res) => {
+      setStatus(res);
+    });
+    PomodoroService.pomodoroTime$.subscribe((res) => {
+      setTime(res);
+    });
+  }, []);
 
   const actions = useMemo<IPomodoroActions>(
     () => ({
-      setEnableTimer: (enable: boolean) => {
-        enableRef.current = enable;
-        if (enable === false)
-          setStatus((prev) => {
-            return { ...prev, focusedTime: 0, restedTime: 0 };
-          });
-      },
       setFocusStep: (step: focusStep) => {
         setSetting((prev) => {
           const newData = { ...prev, focusStep: step };
@@ -95,74 +85,35 @@ const PomodoroProvider = ({ children }: IChildProps) => {
         });
       },
       startFocusing: () => {
-        clearInterval(interval);
-        setStatus({
-          isResting: false,
-          isFocusing: true,
-          focusedTime: 0,
-          restedTime: 0,
-        });
-        interval = setInterval(() => {
-          if (enableRef.current) {
-            setStatus((prev) => {
-              const prevFocusTime =
-                prev.isFocusing !== false ? prev.focusedTime : 0;
-              const newData: IPomodoroStatus = {
-                ...prev,
-                isResting: false,
-                isFocusing: true,
-                focusedTime: prevFocusTime + 1000,
-              };
-              statusRef.current = newData;
-              return newData;
-            });
-          }
-        }, 1000);
+        PomodoroService.setStatus(PomodoroStatus.FOCUSING);
       },
       startResting: () => {
-        clearInterval(interval);
-        interval = setInterval(() => {
-          if (enableRef.current) {
-            setStatus((prev) => {
-              const prevRestTime =
-                prev.isResting !== false ? prev.restedTime : 0;
-              const newData: IPomodoroStatus = {
-                ...prev,
-                isFocusing: false,
-                isResting: true,
-                restedTime: prevRestTime + 1000,
-              };
-              statusRef.current = newData;
-              return newData;
-            });
-          }
-        }, 1000);
+        PomodoroService.setStatus(PomodoroStatus.RESTING);
+      },
+      stopTimer: () => {
+        PomodoroService.setStatus(PomodoroStatus.NONE);
       },
     }),
-    [enableRef.current],
+    [],
   );
 
   useEffect(() => {
-    function updatePomodorBeforeUnload(
-      status: IPomodoroStatus,
-      settings: IPomodoroSettings,
-    ) {
-      updatePomodoroData<IPomodoroStatus>(status, 'status');
+    function updatePomodorBeforeUnload(settings: IPomodoroSettings) {
       updatePomodoroData<IPomodoroSettings>(settings, 'settings');
     }
     window.addEventListener('beforeunload', () =>
-      updatePomodorBeforeUnload(statusRef.current, settingsRef.current),
+      updatePomodorBeforeUnload(settingsRef.current),
     );
     return () => {
       window.removeEventListener('beforeunload', () =>
-        updatePomodorBeforeUnload(statusRef.current, settingsRef.current),
+        updatePomodorBeforeUnload(settingsRef.current),
       );
     };
   }, []);
 
   return (
     <PomodoroActionsContext.Provider value={actions}>
-      <PomodoroValueContext.Provider value={{ settings, status }}>
+      <PomodoroValueContext.Provider value={{ settings, time, status }}>
         {children}
       </PomodoroValueContext.Provider>
     </PomodoroActionsContext.Provider>
@@ -179,7 +130,7 @@ function usePomodoroActions() {
   return value;
 }
 
-function getPomodoroData<T>(type: 'settings' | 'status') {
+function getPomodoroData<T>(type: 'settings') {
   const localKey = 'pomodoro-' + type;
   const existingData = localStorage.getItem(localKey);
 
@@ -190,9 +141,6 @@ function getPomodoroData<T>(type: 'settings' | 'status') {
     switch (type) {
       case 'settings':
         initData = initialPomodoroData.settings as T;
-        break;
-      case 'status':
-        initData = initialPomodoroData.status as T;
         break;
     }
 

--- a/src/molecules/ExtremeModeIndicator.tsx
+++ b/src/molecules/ExtremeModeIndicator.tsx
@@ -3,6 +3,7 @@ import { useExtremeMode, usePomodoroValue } from '../hooks';
 import styled from '@emotion/styled';
 import { TypoAtom } from '../atoms';
 import { formatTime } from '../shared/timeUtils';
+import { PomodoroStatus } from '../services/PomodoroService';
 
 function ExtremeModeIndicator() {
   const { status, settings } = usePomodoroValue();
@@ -26,7 +27,7 @@ function ExtremeModeIndicator() {
     <ExtremeModeContainer>
       {isExtreme && (
         <TypoAtom fontSize="h5" className="extreme-status">
-          {status.isResting && leftTime}
+          {status === PomodoroStatus.RESTING && leftTime}
         </TypoAtom>
       )}
       {isExtreme ? (

--- a/src/services/PomodoroService.ts
+++ b/src/services/PomodoroService.ts
@@ -22,7 +22,6 @@ export const PomodoroService = {
       .pipe(
         tap(() => {
           PomodoroTimeSubject.next(PomodoroTimeSubject.value + 1000);
-          console.log('im timer but..');
         }),
       )
       .subscribe();

--- a/src/services/PomodoroService.ts
+++ b/src/services/PomodoroService.ts
@@ -1,0 +1,30 @@
+import { BehaviorSubject, interval, share, tap } from 'rxjs';
+
+export enum PomodoroStatus {
+  NONE,
+  FOCUSING,
+  RESTING,
+}
+export const PomodoroStatusSubject = new BehaviorSubject<PomodoroStatus>(
+  PomodoroStatus.NONE,
+);
+export const PomodoroTimeSubject = new BehaviorSubject<number>(0);
+
+export const PomodoroService = {
+  pomodoroStatus$: PomodoroStatusSubject.asObservable().pipe(share()),
+  pomodoroTime$: PomodoroTimeSubject.asObservable().pipe(share()),
+  setStatus: (status: PomodoroStatus) => {
+    PomodoroStatusSubject.next(status);
+    PomodoroTimeSubject.next(0);
+  },
+  startTimer: () => {
+    interval(1000)
+      .pipe(
+        tap(() => {
+          PomodoroTimeSubject.next(PomodoroTimeSubject.value + 1000);
+          console.log('im timer but..');
+        }),
+      )
+      .subscribe();
+  },
+};

--- a/src/test/organisms/Records.test.tsx
+++ b/src/test/organisms/Records.test.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from '@emotion/react';
 import { designTheme } from '../../styles/theme';
 import { ITotalFocusTime } from '../../shared/interfaces';
 import { AxiosResponse } from 'axios';
-import PomodoroProvider from '../../hooks/usePomodoro';
+import PomodoroProvider, { pomodoroUnit } from '../../hooks/usePomodoro';
 import { ExtremeModeProvider } from '../../hooks/useExtremeMode';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -55,9 +55,9 @@ describe('Records', () => {
       const fetchRecords = jest.fn(
         jest.fn().mockResolvedValue({
           data: {
-            daily: 207,
-            weekly: 3098,
-            monthly: -20325,
+            daily: 207 * pomodoroUnit,
+            weekly: 3098 * pomodoroUnit,
+            monthly: -20325 * pomodoroUnit,
           } as ITotalFocusTime,
         } as AxiosResponse<ITotalFocusTime>),
       );


### PR DESCRIPTION
* usePomodoro를 리팩토링하고, 영향을 받는 hooks 및 컴포넌트를 수정했습니다.
* cc. #165, #166, #168 

### 주요 변경사항
---
#### AS-IS
* 기존에는 `startFocusing()`, `startResting()`을 시작하면 각각 interval 이 새로 생성되고 실행되었습니다.
* 또한 isFocusing과 isResting이 따로 관리되고 있었습니다.
#### TO-BE
* `isFocusing`과 `isResting`은 서로 독립적인 개념이 아닙니다. 동시에 true 일 수 없습니다. 따라서 `PomodoroStatusSubject`라는 하나의 Subject를 통해 `FOCUSING`, `RESTING`, `NONE`의 세 가지 상태 중에 하나를 가지도록 했습니다. 이는 `useState<PomodoroStatus>()` 와 유사한 개념입니다.
* 또한 집중시간과 휴식시간을 동시에 기록하고 있을 필요가 없다는 점에서, `PomodoroTimeSubject`라는 하나의 Subject의 시간만 1초마다 업데이트 해 주며, `PomodoroStatusSubject`의 값이 업데이트 될 때 0으로 reset해줄 수 있도록 하였습니다. 이는 `useStatus<number>()` 와 유사한 개념입니다.
* `extremeMode` 에서 초기화 성공 이후 invalidateQueries로 todos를 fetch하도록 수정했습니다.
* 테스트 코드를 리팩토링한 코드에 맞추어 수정했습니다.
 ---
* 최대한 기존 구조를 유지하는 방식으로 진행을 했습니다..
* 설명이 부족해서 이해가 안되시는 부분은 언제든 코멘트나 질문 부탁드립니다..🙇‍♂️