### PR TITLE
Bugfix/226 버그 수정

### DIFF
--- a/src/__test__/hooks/useExtremeMode.test.tsx
+++ b/src/__test__/hooks/useExtremeMode.test.tsx
@@ -1,10 +1,4 @@
-import {
-  screen,
-  fireEvent,
-  render,
-  waitFor,
-  act,
-} from '@testing-library/react';
+import { screen, fireEvent, render, waitFor } from '@testing-library/react';
 import {
   useExtremeMode,
   EXTREME_MODE,
@@ -215,20 +209,23 @@ describe('useExtremeMode', () => {
         }),
         jest.fn((key: string) => JSON.stringify('true')),
       );
-      const { getByTestId, findByText } = render(<TestExtremeMode />, {
+      const { findByText, findByTestId } = render(<TestExtremeMode />, {
         wrapper: WrapperComponent,
       });
-      const startResting = getByTestId('startResting');
+      const startResting = await findByTestId('startResting');
 
+      jest.useFakeTimers();
       await waitFor(() => {
         fireEvent.click(startResting);
       });
+      jest.advanceTimersByTime(1000);
 
       const resetNotice1 = await findByText(
         /휴식시간이 초과되었습니다\. 초기화가 진행됩니다\.\.\./i,
       );
       // screen.logTestingPlaygroundURL();
       expect(resetNotice1).toBeInTheDocument();
+      jest.clearAllTimers();
     });
   });
 });

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -135,9 +135,17 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
             </EditContextProvider>
           );
         case 'rest':
-          return <RestCard />;
+          return currentTodo?.todo ? (
+            <RestCard />
+          ) : (
+            <NoTodoCard
+              addTodoHandler={() => {
+                handleClickSideButton('addTodoModal');
+              }}
+            />
+          );
         case 'currentTodo':
-          return currentTodo ? (
+          return currentTodo?.todo ? (
             <CurrentTodoCard />
           ) : (
             <NoTodoCard

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -62,6 +62,7 @@ export const useCurrentTodo = ({
         setFocusedOnTodo(checkLocalStorageAndGetFocusTime(nextTodo) ?? 0);
         if (status == null) actions.startFocusing();
       } else {
+        actions.stopTimer();
         setFocusedOnTodo(0);
       }
     } else {

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -24,17 +24,6 @@ export const useCurrentTodo = ({
   const [focusedOnTodo, setFocusedOnTodo] = useState<number>(0);
   const [canRest, setCanRest] = useState(false);
   const [shouldFocus, setShouldFocus] = useState(false);
-  const subscription = useMemo(
-    () =>
-      PomodoroService.pomodoroStatus$.subscribe((changedStatus) => {
-        if (currentTodo && changedStatus === PomodoroStatus.RESTING) {
-          currentTodo?.categories?.forEach((cantegory) => {
-            timerApi.recordFocusTime(cantegory, time ?? 0);
-          });
-        }
-      }),
-    [],
-  );
 
   const { data: todos } = useQuery<Map<string, TodoEntity[]>>(
     ['todos', currentTodo],
@@ -80,6 +69,15 @@ export const useCurrentTodo = ({
   }, [todos]);
 
   useEffect(() => {
+    const subscription = PomodoroService.pomodoroStatus$.subscribe(
+      (changedStatus) => {
+        if (currentTodo && changedStatus === PomodoroStatus.RESTING) {
+          currentTodo?.categories?.forEach((cantegory) => {
+            timerApi.recordFocusTime(cantegory, time ?? 0);
+          });
+        }
+      },
+    );
     return () => {
       subscription.unsubscribe();
     };

--- a/src/hooks/useExtremeMode.tsx
+++ b/src/hooks/useExtremeMode.tsx
@@ -138,7 +138,7 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
     }
     if (
       isExtreme === true &&
-      prevStatus.current === status &&
+      status === PomodoroStatus.RESTING &&
       resetFlag === false &&
       currentTodo !== null &&
       Number(leftMs) < 0
@@ -153,18 +153,20 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
           handleLeftTime('휴식시간 초과로 모든 기록이 초기화되었습니다.');
           pomodoroActions.stopTimer();
           queryClient.invalidateQueries(['todos']);
+          queryClient.invalidateQueries(['doneTodos']);
           queryClient.invalidateQueries(['category']);
           queryClient.invalidateQueries(['focusedTime']);
+          setResetFlag(true);
         })
         .catch(() => {
           handleLeftTime('초기화가 실패했습니다. 운 좋은 줄 아십시오...');
+          setResetFlag(true);
         });
-      setResetFlag(true);
     }
     if (prevStatus.current != status) {
       setResetFlag(false);
-      prevStatus.current = status;
     }
+    prevStatus.current = status;
   }, [time, status]);
 
   useEffect(() => {
@@ -176,7 +178,7 @@ export const ExtremeModeProvider = ({ children }: IChildProps) => {
       else if (!localExtreme)
         localStorage.setItem(EXTREME_MODE, JSON.stringify(isExtreme));
     }
-  }, [isExtreme, isLoading]);
+  }, [isExtreme, isLoading, prevStatus, status]);
 
   return (
     <ExtremeModeContext.Provider

--- a/src/organisms/CurrentTodoCard.tsx
+++ b/src/organisms/CurrentTodoCard.tsx
@@ -8,6 +8,8 @@ import {
   usePomodoroValue,
 } from '../hooks';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
+import { PomodoroStatus } from '../services/PomodoroService';
 
 export function CurrentTodoCard() {
   const { settings: pomodoroSettings, status, time } = usePomodoroValue();
@@ -21,6 +23,12 @@ export function CurrentTodoCard() {
     },
     actions,
   });
+
+  useEffect(() => {
+    if (status === PomodoroStatus.NONE) {
+      actions.startFocusing();
+    }
+  }, [status, actions]);
 
   return (
     <TransparentAbsoluteCardsParent>


### PR DESCRIPTION
#### 버그 수정
* 익스트림 모드로 인해 초기화 되면 휴식 UI에 아무것도 표출되지 않는 오류 조치 -> NoTodoCard 가 표시되도록
* 익스트림 모드로 인해 초기화 될 때 invalidate 하는 cache key에 'doneTodos' 추가 (이미 한 일 목록이 남아있는 오류 조치)
* 다음 투두가 없는 경우 PomodoroStatus가 NONE 되도록 수정
* 현재 투두가 하나도 없는 경우 신규 투두를 만들고 집중 화면 진입 시 시간이 안 가는 오류 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback UI for when there is no current todo item, prompting users to add a new todo during rest or current todo states.

* **Bug Fixes**
  * Ensured the timer stops when there are no todos to focus on.
  * Improved reset logic and query cache handling in extreme mode for more reliable behavior.
  * Automatically starts focusing when the Pomodoro timer is inactive.

* **Tests**
  * Improved test reliability by handling asynchronous UI updates and timer-based behavior more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->