### PR TITLE
Refactor/240 집중 화면 신규 디자인 반영

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,7 +4,7 @@
 echo "Running tests before push..."
 
 # Run your test command
-npm test
+CI=true npm test
 
 # Check if the test command failed
 if [ $? -ne 0 ]; then

--- a/public/icon/stop-dark.svg
+++ b/public/icon/stop-dark.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="26" height="26" fill="#DBFE77"/>
+</svg>

--- a/public/icon/stop-light.svg
+++ b/public/icon/stop-light.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="26" height="26" fill="#523EA1"/>
+</svg>

--- a/src/__test__/molecules/CurrentTodo.test.tsx
+++ b/src/__test__/molecules/CurrentTodo.test.tsx
@@ -19,6 +19,7 @@ describe('CurrentTodo', () => {
           focusStep={10}
           focusedOnTodo={10}
           startResting={jest.fn()}
+          currentRound={0}
         ></CurrentTodo>
         ,
       </ThemeProvider>,
@@ -35,17 +36,12 @@ describe('CurrentTodo', () => {
       expect(getByText(mockCurrentTodo.todo)).toBeDefined();
     });
 
-    it('카테고리를 렌더링한다', () => {
-      const { getByText } = component;
-      mockCurrentTodo.categories?.forEach((category) => {
-        expect(getByText(category)).toBeDefined();
-      });
-    });
-
     it('시간(뽀모도로 단위)를 렌더링한다', () => {
       const { getByText } = component;
       expect(
-        getByText(mockCurrentTodo.duration, { exact: false }),
+        getByText(`🍅 `.repeat(mockCurrentTodo.duration).trim(), {
+          exact: false,
+        }),
       ).toBeDefined();
     });
   });

--- a/src/atoms/CardAnimationPlayerAtom.tsx
+++ b/src/atoms/CardAnimationPlayerAtom.tsx
@@ -98,5 +98,6 @@ export const CardAnimationPlayerAtom = ({
 };
 const StyledCardAnimationPlayerWrapper = styled.div`
   position: absolute;
-  transform-origin: bottom left;
+  transform-origin: center;
+  width: 100%;
 `;

--- a/src/atoms/CardAtom.tsx
+++ b/src/atoms/CardAtom.tsx
@@ -28,11 +28,11 @@ export const CardAtom = styled.div<{
     }
   }};
   box-shadow: ${({ theme: { shadow } }) => shadow.container};
-  border-radius: 30px;
+  border-radius: 28px;
   padding: ${({ padding }) => padding ?? '2rem 2.75rem'};
   margin: ${({ margin }) => margin ?? '0rem'};
-  width: ${({ w }) => w ?? '53.75rem'};
-  height: ${({ h }) => h ?? '20rem'};
+  width: ${({ w }) => w ?? '59rem'};
+  height: ${({ h }) => h ?? '28.75rem'};
   max-width: 100%;
   max-height: 100%;
   display: flex;
@@ -42,4 +42,9 @@ export const CardAtom = styled.div<{
   box-sizing: border-box;
   transition: all 0.3s ease-in-out;
   z-index: 1;
+  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
+    ${({ theme }) => theme.responsiveDevice.mobile} {
+    width: 100%;
+    height: calc(100vh - 13.25rem);
+  }
 `;

--- a/src/atoms/CardAtom.tsx
+++ b/src/atoms/CardAtom.tsx
@@ -40,11 +40,13 @@ export const CardAtom = styled.div<{
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  transition: all 0.3s ease-in-out;
+  transition: width 0.3s ease-in-out, height 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
   z-index: 1;
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
     width: 100%;
     height: calc(100vh - 13.25rem);
+    padding: ${({ padding }) => padding ?? '1.25rem'};
   }
 `;

--- a/src/atoms/SideBtnAtom.tsx
+++ b/src/atoms/SideBtnAtom.tsx
@@ -4,14 +4,45 @@ import { ButtonName } from '../styles/emotion';
 export interface SideBtnAtomProps {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   btnStyle: ButtonName;
+  btnType?: 'text' | 'icon';
   className?: string;
   ariaLabel?: string;
   type?: 'submit' | 'reset' | 'button';
   disabled?: boolean;
   focused?: boolean;
+  children?: React.ReactNode;
 }
 
-export const SideBtnAtom = styled.button<SideBtnAtomProps>`
+export const SideBtnAtom = ({
+  onClick,
+  btnStyle,
+  className,
+  ariaLabel,
+  type = 'button',
+  disabled = false,
+  focused = false,
+  btnType = 'text',
+  children,
+}: SideBtnAtomProps) => {
+  return (
+    <BaseBtnAtom
+      btnType={btnType}
+      onClick={onClick}
+      btnStyle={btnStyle}
+      className={className}
+      aria-label={ariaLabel}
+      type={type}
+      disabled={disabled}
+      focused={focused}
+    >
+      {children}
+    </BaseBtnAtom>
+  );
+};
+
+const BaseBtnAtom = styled.button<
+  Pick<SideBtnAtomProps, 'btnStyle' | 'focused' | 'btnType'>
+>`
   background-color: transparent;
   color: ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
   border: 1px solid
@@ -25,16 +56,16 @@ export const SideBtnAtom = styled.button<SideBtnAtomProps>`
   font-weight: ${({ theme }) => theme.fontSize.body.weight};
   line-height: ${({ theme }) => theme.fontSize.body.lineHeight};
   transition: background-color 0.3s, border-color 0.3s;
+
   &:hover {
     background-color: ${({ theme, btnStyle }) =>
       theme.button[btnStyle].default.backgroundColor};
     color: ${({ theme, btnStyle }) => theme.button[btnStyle].hover.color};
   }
   &:active {
-    background-color: ${({ theme, btnStyle: btnType }) =>
-      theme.button[btnType].click.backgroundColor};
-    color: ${({ theme, btnStyle: btnType }) =>
-      theme.button[btnType].click.color};
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle].click.backgroundColor};
+    color: ${({ theme, btnStyle }) => theme.button[btnStyle].click.color};
   }
   &:disabled {
     background-color: ${({ theme, btnStyle }) =>
@@ -42,6 +73,16 @@ export const SideBtnAtom = styled.button<SideBtnAtomProps>`
     color: ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
     cursor: not-allowed;
   }
+
+  ${({ btnType }) =>
+    btnType === 'icon' &&
+    `
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    text-align: center;
+    justify-content: center;
+  `}
 
   ${({ focused, theme, btnStyle: btnType }) =>
     focused &&

--- a/src/atoms/SideBtnAtom.tsx
+++ b/src/atoms/SideBtnAtom.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import { ButtonName } from '../styles/emotion';
+
+export interface SideBtnAtomProps {
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  btnStyle: ButtonName;
+  className?: string;
+  ariaLabel?: string;
+  type?: 'submit' | 'reset' | 'button';
+  disabled?: boolean;
+}
+
+export const SideBtnAtom = styled.button<SideBtnAtomProps>`
+  background-color: transparent;
+  color: ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
+  border: 1px solid
+    ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
+  padding: 0.25rem 1.5rem;
+  border-radius: 1.25rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSize.body.size};
+  font-weight: ${({ theme }) => theme.fontSize.body.weight};
+  line-height: ${({ theme }) => theme.fontSize.body.lineHeight};
+  transition: background-color 0.3s, border-color 0.3s;
+  &:hover {
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle].default.backgroundColor};
+    color: ${({ theme, btnStyle }) => theme.button[btnStyle].hover.color};
+  }
+  &:active {
+    background-color: ${({ theme, btnStyle: btnType }) =>
+      theme.button[btnType].click.backgroundColor};
+    color: ${({ theme, btnStyle: btnType }) =>
+      theme.button[btnType].click.color};
+  }
+  &:disabled {
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle].default.backgroundColor};
+    color: ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
+    cursor: not-allowed;
+  }
+`;

--- a/src/atoms/SideBtnAtom.tsx
+++ b/src/atoms/SideBtnAtom.tsx
@@ -8,6 +8,7 @@ export interface SideBtnAtomProps {
   ariaLabel?: string;
   type?: 'submit' | 'reset' | 'button';
   disabled?: boolean;
+  focused?: boolean;
 }
 
 export const SideBtnAtom = styled.button<SideBtnAtomProps>`
@@ -41,4 +42,11 @@ export const SideBtnAtom = styled.button<SideBtnAtomProps>`
     color: ${({ theme, btnStyle }) => theme.button[btnStyle].default.color};
     cursor: not-allowed;
   }
+
+  ${({ focused, theme, btnStyle: btnType }) =>
+    focused &&
+    `
+    background-color: ${theme.button[btnType].click.backgroundColor} !important;
+    color: ${theme.button[btnType].click.color} !important;
+  `}
 `;

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import { useIsMobile } from '../hooks';
 
-const TodoProgressBarContainer = styled.div<{
+const TodoProgressBarContainer = styled('div', {
+  shouldForwardProp: (prop) => !['progress', 'type'].includes(prop as string),
+})<{
   progress: number;
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
 }>`
@@ -458,52 +460,3 @@ export const TodoProgressBarAtom = (props: {
     </TodoProgressBarContainer>
   );
 };
-
-// export const TodoProgressBarAtom = styled.div<{
-//   progress: number;
-//   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
-// }>`
-//   background-color: ${({ theme, type }) => {
-//     switch (type) {
-//       case 'primary1':
-//         return theme.color.backgroundColor.primary1;
-//       case 'primary2':
-//         return theme.color.backgroundColor.primary2;
-//       case 'extreme1':
-//         return theme.color.backgroundColor.extreme_dark;
-//       case 'extreme2':
-//         return theme.color.backgroundColor.extreme_orange;
-//     }
-//   }};
-//   height: 0.75rem;
-//   width: 100%;
-//   border-radius: 1.75rem;
-//   display: flex;
-//   align-items: center;
-//   position: relative;
-//   box-sizing: border-box;
-//   overflow: hidden;
-//   .progress {
-//     width: ${({ progress }) => `${progress}%`};
-//     height: 100%;
-//     line-height: 2.875rem;
-//     border-radius: 3.125rem;
-//     background: ${({ theme }) => theme.color.backgroundColor.extreme_orange};
-//     transition: all 0.2s ease-in-out;
-//   }
-//   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
-//     ${({ theme }) => theme.responsiveDevice.mobile} {
-//     width: 100%;
-//     height: 100%;
-//     align-items: flex-start;
-//     justify-content: center;
-//     padding: 1rem 0 1rem 0;
-//     .progress {
-//       height: ${({ progress }) => `${progress}%`};
-//       width: 70%;
-//       overflow: hidden;
-//       padding: 0;
-//       color: transparent;
-//     }
-//   }
-// `;

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 import { useIsMobile } from '../hooks';
 
 const TodoProgressBarContainer = styled('div', {
-  shouldForwardProp: (prop) => !['progress', 'type'].includes(prop as string),
+  shouldForwardProp: (prop) =>
+    // 아래 aria-* 속성들은 div 요소에 전달되어야 하므로 필터링하지 않습니다.
+    ['aria-valuemin', 'aria-valuemax', 'aria-valuenow', 'children'].includes(
+      prop,
+    ),
 })<{
   progress: number;
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
@@ -90,8 +94,15 @@ export const TodoProgressBarAtom = (props: {
   children?: React.ReactNode;
 }) => {
   const isMobile = useIsMobile();
+  const clamped = Math.max(0, Math.min(100, props.progress));
   return (
-    <TodoProgressBarContainer progress={props.progress} type={props.type}>
+    <TodoProgressBarContainer
+      type={props.type}
+      progress={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(clamped)}
+    >
       {isMobile ? (
         <svg
           id="progress-bar-background"

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -5,7 +5,7 @@ const TodoProgressBarContainer = styled.div<{
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
 }>`
   width: 44.99rem;
-  height: 10.02rem;
+  height: 11rem;
   pointer-events: none;
   position: relative;
 

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -1,50 +1,315 @@
 import styled from '@emotion/styled';
 
-export const TodoProgressBarAtom = styled.div<{
+const TodoProgressBarContainer = styled.div<{
   progress: number;
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
 }>`
-  background-color: ${({ theme, type }) => {
-    switch (type) {
-      case 'primary1':
-        return theme.color.backgroundColor.primary1;
-      case 'primary2':
-        return theme.color.backgroundColor.primary2;
-      case 'extreme1':
-        return theme.color.backgroundColor.extreme_dark;
-      case 'extreme2':
-        return theme.color.backgroundColor.extreme_orange;
-    }
-  }};
-  height: 0.75rem;
-  width: 100%;
-  border-radius: 1.75rem;
-  display: flex;
-  align-items: center;
+  width: 44.99rem;
+  height: 10.02rem;
+  pointer-events: none;
   position: relative;
-  box-sizing: border-box;
-  overflow: hidden;
-  .progress {
-    width: ${({ progress }) => `${progress}%`};
-    height: 100%;
-    line-height: 2.875rem;
-    border-radius: 3.125rem;
-    background: ${({ theme }) => theme.color.backgroundColor.extreme_orange};
-    transition: all 0.2s ease-in-out;
-  }
-  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
-    ${({ theme }) => theme.responsiveDevice.mobile} {
+
+  #progress-bar-background {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
     width: 100%;
     height: 100%;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 1rem 0 1rem 0;
-    .progress {
-      height: ${({ progress }) => `${progress}%`};
-      width: 70%;
-      overflow: hidden;
-      padding: 0;
-      color: transparent;
+  }
+  #progress-bar-ticks {
+    position: absolute;
+    top: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 92.75%;
+    height: 89.58%;
+  }
+  #progress-bar-foreground {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    height: 100%;
+    > path {
+      stroke: ${({ theme }) => theme.color.backgroundColor.extreme_orange};
+      stroke-width: 12px;
+      stroke-linecap: round;
+      stroke-dasharray: ${(props) => `${props.progress} 100`};
+      stroke-dashoffset: 0;
+      transition: stroke-dasharray 0.2s ease-in-out;
     }
   }
+
+  .background {
+    fill: ${({ theme, type }) => {
+      switch (type) {
+        case 'primary1':
+          return theme.color.backgroundColor.primary1;
+        case 'primary2':
+          return theme.color.backgroundColor.primary2;
+        case 'extreme1':
+          return theme.color.backgroundColor.extreme_dark;
+        case 'extreme2':
+          return theme.color.backgroundColor.extreme_orange;
+      }
+    }};
+  }
 `;
+
+export const TodoProgressBarAtom = (props: {
+  progress: number;
+  type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
+  children?: React.ReactNode;
+}) => {
+  return (
+    <TodoProgressBarContainer progress={props.progress} type={props.type}>
+      <svg
+        id="progress-bar-background"
+        className="background"
+        width="732"
+        height="144"
+        viewBox="0 0 732 144"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M729.753 141.925C731.796 139.559 731.534 135.981 729.148 133.961C627.721 48.1192 499.266 0.657765 366.27 0.00678025C233.275 -0.644205 104.361 45.5574 2.09862 130.403C-0.307114 132.399 -0.604172 135.974 1.41577 138.36C3.4357 140.746 7.00766 141.038 9.41379 139.042C109.617 55.94 235.917 10.6889 366.215 11.3267C496.513 11.9644 622.364 58.4498 721.749 142.529C724.135 144.548 727.71 144.291 729.753 141.925Z" />
+      </svg>
+      <svg
+        id="progress-bar-foreground"
+        className="foreground"
+        width="732"
+        height="144"
+        viewBox="0 0 732 144"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          pathLength={100}
+          d="M6 135.058C103.14 54.457 227.911 6 364 6C502.015 6 628.389 55.8384 726.108 138.5"
+        />
+      </svg>
+      <svg
+        id="progress-bar-ticks"
+        className="background"
+        width="679"
+        height="129"
+        viewBox="0 0 679 129"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect x="337" width="4" height="8" rx="2" />
+        <rect
+          x="370.254"
+          y="0.882812"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(3.59027 370.254 0.882812)"
+        />
+        <rect
+          x="403.387"
+          y="3.84668"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(7.18054 403.387 3.84668)"
+        />
+        <rect
+          x="436.27"
+          y="8.87891"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(10.7708 436.27 8.87891)"
+        />
+        <rect
+          x="468.773"
+          y="15.9609"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(14.3611 468.773 15.9609)"
+        />
+        <rect
+          x="500.77"
+          y="25.0645"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(17.9513 500.77 25.0645)"
+        />
+        <rect
+          x="532.133"
+          y="36.1533"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(21.5416 532.133 36.1533)"
+        />
+        <rect
+          x="562.74"
+          y="49.1846"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(25.1319 562.74 49.1846)"
+        />
+        <rect
+          x="592.471"
+          y="64.1074"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(28.7222 592.471 64.1074)"
+        />
+        <rect
+          x="621.209"
+          y="80.8623"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(32.3124 621.209 80.8623)"
+        />
+        <rect
+          x="648.842"
+          y="99.3838"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(35.9027 648.842 99.3838)"
+        />
+        <rect
+          x="675.26"
+          y="119.6"
+          width="4"
+          height="8"
+          rx="2"
+          transform="rotate(39.493 675.26 119.6)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-1 0 0 1 341.346 0)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.998037 0.062621 0.062621 0.998037 308.092 0.882812)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.992157 0.124996 0.124996 0.992157 274.959 3.84668)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.982383 0.186881 0.186881 0.982383 242.076 8.87891)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.968752 0.248032 0.248032 0.968752 209.572 15.9609)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.951319 0.308209 0.308209 0.951319 177.576 25.0645)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.930151 0.367177 0.367177 0.930151 146.213 36.1533)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.905333 0.424703 0.424703 0.905333 115.605 49.1846)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.876961 0.480563 0.480563 0.876961 85.875 64.1074)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.845146 0.534536 0.534536 0.845146 57.1367 80.8623)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.810014 0.586411 0.586411 0.810014 29.5039 99.3838)"
+        />
+        <rect
+          width="4"
+          height="8"
+          rx="2"
+          transform="matrix(-0.771703 0.635984 0.635984 0.771703 3.08594 119.6)"
+        />
+      </svg>
+    </TodoProgressBarContainer>
+  );
+};
+
+// export const TodoProgressBarAtom = styled.div<{
+//   progress: number;
+//   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
+// }>`
+//   background-color: ${({ theme, type }) => {
+//     switch (type) {
+//       case 'primary1':
+//         return theme.color.backgroundColor.primary1;
+//       case 'primary2':
+//         return theme.color.backgroundColor.primary2;
+//       case 'extreme1':
+//         return theme.color.backgroundColor.extreme_dark;
+//       case 'extreme2':
+//         return theme.color.backgroundColor.extreme_orange;
+//     }
+//   }};
+//   height: 0.75rem;
+//   width: 100%;
+//   border-radius: 1.75rem;
+//   display: flex;
+//   align-items: center;
+//   position: relative;
+//   box-sizing: border-box;
+//   overflow: hidden;
+//   .progress {
+//     width: ${({ progress }) => `${progress}%`};
+//     height: 100%;
+//     line-height: 2.875rem;
+//     border-radius: 3.125rem;
+//     background: ${({ theme }) => theme.color.backgroundColor.extreme_orange};
+//     transition: all 0.2s ease-in-out;
+//   }
+//   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
+//     ${({ theme }) => theme.responsiveDevice.mobile} {
+//     width: 100%;
+//     height: 100%;
+//     align-items: flex-start;
+//     justify-content: center;
+//     padding: 1rem 0 1rem 0;
+//     .progress {
+//       height: ${({ progress }) => `${progress}%`};
+//       width: 70%;
+//       overflow: hidden;
+//       padding: 0;
+//       color: transparent;
+//     }
+//   }
+// `;

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
+import { useIsMobile } from '../hooks';
 
 const TodoProgressBarContainer = styled.div<{
   progress: number;
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
 }>`
-  width: 44.99rem;
-  height: 11rem;
+  width: 100%;
+  height: 90%;
   pointer-events: none;
   position: relative;
 
@@ -16,6 +17,15 @@ const TodoProgressBarContainer = styled.div<{
     transform: translateX(-50%);
     width: 100%;
     height: 100%;
+    > path {
+      stroke: ${({ theme, type }) =>
+        type !== 'primary2' && type !== 'extreme2'
+          ? theme.color.backgroundColor.primary1
+          : theme.color.backgroundColor.primary2};
+      stroke-width: 12px;
+      stroke-linecap: round;
+      fill: none;
+    }
   }
   #progress-bar-ticks {
     position: absolute;
@@ -56,6 +66,20 @@ const TodoProgressBarContainer = styled.div<{
       }
     }};
   }
+
+  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
+    ${({ theme }) => theme.responsiveDevice.mobile} {
+    width: 100%;
+    #progress-bar-background,
+    #progress-bar-foreground {
+      > path {
+        stroke-width: 0.5rem;
+      }
+    }
+    #progress-bar-ticks {
+      top: 1.25rem;
+    }
+  }
 `;
 
 export const TodoProgressBarAtom = (props: {
@@ -63,204 +87,374 @@ export const TodoProgressBarAtom = (props: {
   type: 'primary1' | 'primary2' | 'extreme1' | 'extreme2';
   children?: React.ReactNode;
 }) => {
+  const isMobile = useIsMobile();
   return (
     <TodoProgressBarContainer progress={props.progress} type={props.type}>
-      <svg
-        id="progress-bar-background"
-        className="background"
-        width="732"
-        height="144"
-        viewBox="0 0 732 144"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M729.753 141.925C731.796 139.559 731.534 135.981 729.148 133.961C627.721 48.1192 499.266 0.657765 366.27 0.00678025C233.275 -0.644205 104.361 45.5574 2.09862 130.403C-0.307114 132.399 -0.604172 135.974 1.41577 138.36C3.4357 140.746 7.00766 141.038 9.41379 139.042C109.617 55.94 235.917 10.6889 366.215 11.3267C496.513 11.9644 622.364 58.4498 721.749 142.529C724.135 144.548 727.71 144.291 729.753 141.925Z" />
-      </svg>
-      <svg
-        id="progress-bar-foreground"
-        className="foreground"
-        width="732"
-        height="144"
-        viewBox="0 0 732 144"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          pathLength={100}
-          d="M6 135.058C103.14 54.457 227.911 6 364 6C502.015 6 628.389 55.8384 726.108 138.5"
-        />
-      </svg>
-      <svg
-        id="progress-bar-ticks"
-        className="background"
-        width="679"
-        height="129"
-        viewBox="0 0 679 129"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect x="337" width="4" height="8" rx="2" />
-        <rect
-          x="370.254"
-          y="0.882812"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(3.59027 370.254 0.882812)"
-        />
-        <rect
-          x="403.387"
-          y="3.84668"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(7.18054 403.387 3.84668)"
-        />
-        <rect
-          x="436.27"
-          y="8.87891"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(10.7708 436.27 8.87891)"
-        />
-        <rect
-          x="468.773"
-          y="15.9609"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(14.3611 468.773 15.9609)"
-        />
-        <rect
-          x="500.77"
-          y="25.0645"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(17.9513 500.77 25.0645)"
-        />
-        <rect
-          x="532.133"
-          y="36.1533"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(21.5416 532.133 36.1533)"
-        />
-        <rect
-          x="562.74"
-          y="49.1846"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(25.1319 562.74 49.1846)"
-        />
-        <rect
-          x="592.471"
-          y="64.1074"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(28.7222 592.471 64.1074)"
-        />
-        <rect
-          x="621.209"
-          y="80.8623"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(32.3124 621.209 80.8623)"
-        />
-        <rect
-          x="648.842"
-          y="99.3838"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(35.9027 648.842 99.3838)"
-        />
-        <rect
-          x="675.26"
-          y="119.6"
-          width="4"
-          height="8"
-          rx="2"
-          transform="rotate(39.493 675.26 119.6)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-1 0 0 1 341.346 0)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.998037 0.062621 0.062621 0.998037 308.092 0.882812)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.992157 0.124996 0.124996 0.992157 274.959 3.84668)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.982383 0.186881 0.186881 0.982383 242.076 8.87891)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.968752 0.248032 0.248032 0.968752 209.572 15.9609)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.951319 0.308209 0.308209 0.951319 177.576 25.0645)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.930151 0.367177 0.367177 0.930151 146.213 36.1533)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.905333 0.424703 0.424703 0.905333 115.605 49.1846)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.876961 0.480563 0.480563 0.876961 85.875 64.1074)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.845146 0.534536 0.534536 0.845146 57.1367 80.8623)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.810014 0.586411 0.586411 0.810014 29.5039 99.3838)"
-        />
-        <rect
-          width="4"
-          height="8"
-          rx="2"
-          transform="matrix(-0.771703 0.635984 0.635984 0.771703 3.08594 119.6)"
-        />
-      </svg>
+      {isMobile ? (
+        <svg
+          id="progress-bar-background"
+          className="background"
+          width="316"
+          height="78"
+          viewBox="0 0 316 78"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            pathLength={100}
+            d="M4 74C41.398 31.1059 96.4445 4 157.822 4C219.297 4 274.421 31.192 311.822 74.2044"
+          />
+        </svg>
+      ) : (
+        <svg
+          id="progress-bar-background"
+          className="background"
+          width="732"
+          height="144"
+          viewBox="0 0 732 144"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            pathLength={100}
+            d="M6 135.058C103.14 54.457 227.911 6 364 6C502.015 6 628.389 55.8384 726.108 138.5"
+          />
+        </svg>
+      )}
+      {isMobile ? (
+        <svg
+          id="progress-bar-foreground"
+          className="foreground"
+          width="316"
+          height="78"
+          viewBox="0 0 316 78"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            pathLength={100}
+            d="M4 74C41.398 31.1059 96.4445 4 157.822 4C219.297 4 274.421 31.192 311.822 74.2044"
+          />
+        </svg>
+      ) : (
+        <svg
+          id="progress-bar-foreground"
+          className="foreground"
+          width="732"
+          height="144"
+          viewBox="0 0 732 144"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            pathLength={100}
+            d="M6 135.058C103.14 54.457 227.911 6 364 6C502.015 6 628.389 55.8384 726.108 138.5"
+          />
+        </svg>
+      )}
+      {isMobile ? (
+        <svg
+          id="progress-bar-ticks"
+          className="background"
+          width="277"
+          height="67"
+          viewBox="0 0 277 67"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="137.002" width="3" height="6" rx="1.5" />
+          <rect
+            x="156.324"
+            y="0.859375"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(6 156.324 0.859375)"
+          />
+          <rect
+            x="175.451"
+            y="3.7334"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(12 175.451 3.7334)"
+          />
+          <rect
+            x="194.172"
+            y="8.5918"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(18 194.172 8.5918)"
+          />
+          <rect
+            x="212.283"
+            y="15.3799"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(24 212.283 15.3799)"
+          />
+          <rect
+            x="229.586"
+            y="24.0244"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(30 229.586 24.0244)"
+          />
+          <rect
+            x="245.891"
+            y="34.4297"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(36 245.891 34.4297)"
+          />
+          <rect
+            x="261.018"
+            y="46.4824"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(42 261.018 46.4824)"
+          />
+          <rect
+            x="274.801"
+            y="60.0508"
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="rotate(48 274.801 60.0508)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-1 0 0 1 139.809 0)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.994522 0.104528 0.104528 0.994522 120.486 0.859375)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.978148 0.207912 0.207912 0.978148 101.359 3.7334)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.951057 0.309017 0.309017 0.951057 82.6387 8.5918)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.913545 0.406737 0.406737 0.913545 64.5273 15.3799)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.866025 0.5 0.5 0.866025 47.2246 24.0244)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.809017 0.587785 0.587785 0.809017 30.9199 34.4297)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.743145 0.669131 0.669131 0.743145 15.793 46.4824)"
+          />
+          <rect
+            width="3"
+            height="6"
+            rx="1.5"
+            transform="matrix(-0.669131 0.743145 0.743145 0.669131 2.00977 60.0508)"
+          />
+        </svg>
+      ) : (
+        <svg
+          id="progress-bar-ticks"
+          className="background"
+          width="679"
+          height="129"
+          viewBox="0 0 679 129"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="337" width="4" height="8" rx="2" />
+          <rect
+            x="370.254"
+            y="0.882812"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(3.59027 370.254 0.882812)"
+          />
+          <rect
+            x="403.387"
+            y="3.84668"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(7.18054 403.387 3.84668)"
+          />
+          <rect
+            x="436.27"
+            y="8.87891"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(10.7708 436.27 8.87891)"
+          />
+          <rect
+            x="468.773"
+            y="15.9609"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(14.3611 468.773 15.9609)"
+          />
+          <rect
+            x="500.77"
+            y="25.0645"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(17.9513 500.77 25.0645)"
+          />
+          <rect
+            x="532.133"
+            y="36.1533"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(21.5416 532.133 36.1533)"
+          />
+          <rect
+            x="562.74"
+            y="49.1846"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(25.1319 562.74 49.1846)"
+          />
+          <rect
+            x="592.471"
+            y="64.1074"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(28.7222 592.471 64.1074)"
+          />
+          <rect
+            x="621.209"
+            y="80.8623"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(32.3124 621.209 80.8623)"
+          />
+          <rect
+            x="648.842"
+            y="99.3838"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(35.9027 648.842 99.3838)"
+          />
+          <rect
+            x="675.26"
+            y="119.6"
+            width="4"
+            height="8"
+            rx="2"
+            transform="rotate(39.493 675.26 119.6)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-1 0 0 1 341.346 0)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.998037 0.062621 0.062621 0.998037 308.092 0.882812)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.992157 0.124996 0.124996 0.992157 274.959 3.84668)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.982383 0.186881 0.186881 0.982383 242.076 8.87891)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.968752 0.248032 0.248032 0.968752 209.572 15.9609)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.951319 0.308209 0.308209 0.951319 177.576 25.0645)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.930151 0.367177 0.367177 0.930151 146.213 36.1533)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.905333 0.424703 0.424703 0.905333 115.605 49.1846)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.876961 0.480563 0.480563 0.876961 85.875 64.1074)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.845146 0.534536 0.534536 0.845146 57.1367 80.8623)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.810014 0.586411 0.586411 0.810014 29.5039 99.3838)"
+          />
+          <rect
+            width="4"
+            height="8"
+            rx="2"
+            transform="matrix(-0.771703 0.635984 0.635984 0.771703 3.08594 119.6)"
+          />
+        </svg>
+      )}
     </TodoProgressBarContainer>
   );
 };

--- a/src/atoms/TodoProgressBarAtom.tsx
+++ b/src/atoms/TodoProgressBarAtom.tsx
@@ -99,9 +99,11 @@ export const TodoProgressBarAtom = (props: {
     <TodoProgressBarContainer
       type={props.type}
       progress={clamped}
+      aria-label="진행률"
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={Math.round(clamped)}
+      aria-valuetext={`${Math.round(clamped)}% 완료`}
     >
       {isMobile ? (
         <svg

--- a/src/atoms/TypoAtom.tsx
+++ b/src/atoms/TypoAtom.tsx
@@ -50,11 +50,11 @@ const Typo = styled.span<ITypoProps>`
 
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
-    ${({ fontSize, theme }) =>
+    font-size: ${({ fontSize, theme }) =>
       fontSize === 'clock'
-        ? 'font-size: 5.25rem;'
+        ? '5.25rem;'
         : fontSize
         ? theme.fontSize[fontSize].size
-        : theme.fontSize.body.size}
+        : theme.fontSize.body.size};
   }
 `;

--- a/src/atoms/TypoAtom.tsx
+++ b/src/atoms/TypoAtom.tsx
@@ -47,4 +47,14 @@ const Typo = styled.span<ITypoProps>`
     fontSize
       ? (theme.fontSize[fontSize].lineHeight as string)
       : (theme.fontSize.body.lineHeight as string)};
+
+  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
+    ${({ theme }) => theme.responsiveDevice.mobile} {
+    ${({ fontSize, theme }) =>
+      fontSize === 'clock'
+        ? 'font-size: 5.25rem;'
+        : fontSize
+        ? theme.fontSize[fontSize].size
+        : theme.fontSize.body.size}
+  }
 `;

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -198,8 +198,6 @@ export const AddTodo = ({ handleClose }: IAddTodoProps) => {
       }}
     >
       <AddTodoWrapper
-        w="53.75rem"
-        h="20rem"
         padding="1.5rem"
         className="card"
         onSubmit={handleAddSubmit}

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -3,6 +3,7 @@ import {
   FormEvent,
   KeyboardEventHandler,
   ReactEventHandler,
+  ReactNode,
   useCallback,
   useState,
 } from 'react';
@@ -18,7 +19,7 @@ import {
 import { CategoryInput } from '../molecules';
 
 /* custom hooks */
-import { usePomodoroValue } from '../hooks';
+import { useIsMobile, usePomodoroValue } from '../hooks';
 
 /* custom functions or methods */
 import { todosApi } from '../shared/apis';
@@ -42,11 +43,15 @@ import { startOfYesterday } from 'date-fns';
 
 interface IAddTodoProps {
   handleClose: () => void;
+  mobileTopButtonSlot?: ReactNode;
 }
 
 const ramdomTagColorList = RandomTagColorList.getInstance();
 
-export const AddTodo = ({ handleClose }: IAddTodoProps) => {
+export const AddTodo = ({
+  handleClose,
+  mobileTopButtonSlot,
+}: IAddTodoProps) => {
   const [title, setTitle] = useState('');
   const [titleError, setTitleError] = useState(false);
   const [category, setCategory] = useState('');
@@ -55,6 +60,7 @@ export const AddTodo = ({ handleClose }: IAddTodoProps) => {
     undefined,
   );
   const [tomato, setTomato] = useState(1);
+  const isMobile = useIsMobile();
 
   const queryClient = useQueryClient();
 
@@ -203,6 +209,20 @@ export const AddTodo = ({ handleClose }: IAddTodoProps) => {
         onSubmit={handleAddSubmit}
       >
         <MainWrapper>
+          {isMobile && (
+            <div className="mobile-header-wrapper">
+              <div className="mobile-top-button-wrapper">
+                {mobileTopButtonSlot}
+              </div>
+              <BtnAtom
+                handleOnClick={handleClose}
+                ariaLabel="close"
+                tabIndex={3}
+              >
+                <IconAtom size={2} alt="close" src="icon/closeDark.svg" />
+              </BtnAtom>
+            </div>
+          )}
           <TitleWrapper>
             <label htmlFor="title">
               <InputAtom.Underline
@@ -227,9 +247,15 @@ export const AddTodo = ({ handleClose }: IAddTodoProps) => {
                 tabIndex={0}
               />
             </label>
-            <BtnAtom handleOnClick={handleClose} ariaLabel="close" tabIndex={3}>
-              <IconAtom size={2} alt="close" src="icon/closeDark.svg" />
-            </BtnAtom>
+            {!isMobile && (
+              <BtnAtom
+                handleOnClick={handleClose}
+                ariaLabel="close"
+                tabIndex={3}
+              >
+                <IconAtom size={2} alt="close" src="icon/closeDark.svg" />
+              </BtnAtom>
+            )}
           </TitleWrapper>
           <CategoryWrapper>
             <CategoryInput
@@ -301,6 +327,14 @@ const MainWrapper = styled.div`
   flex-direction: column;
   row-gap: 1rem;
   width: 100%;
+  .mobile-header-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    .mobile-top-button-wrapper {
+      flex-shrink: 0;
+    }
+  }
 `;
 
 const TitleWrapper = styled.div`

--- a/src/components/MainTodo/MainTodoStyles.tsx
+++ b/src/components/MainTodo/MainTodoStyles.tsx
@@ -31,6 +31,9 @@ export const MainTodoCenter = styled.div`
   align-items: center;
   gap: 0.75rem;
   width: 100%;
+  .side-buttons {
+    width: 59rem;
+  }
   .center {
     width: 59rem;
     height: 28.75rem;
@@ -62,6 +65,9 @@ export const MainTodoCenter = styled.div`
     .center {
       width: 89.9%;
       height: calc(100vh - 13.25rem);
+    }
+    .side-buttons {
+      width: 89.9%;
     }
   }
 `;

--- a/src/components/MainTodo/MainTodoStyles.tsx
+++ b/src/components/MainTodo/MainTodoStyles.tsx
@@ -16,6 +16,7 @@ export const MainTodoContentWrapper = styled.div`
   align-items: center;
   flex-direction: column;
   gap: 4rem;
+  width: 100%;
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
     width: 100%;
@@ -27,10 +28,12 @@ export const MainTodoCenter = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: center;
   gap: 0.75rem;
+  width: 100%;
   .center {
-    width: 53.75rem;
-    height: 20rem;
+    width: 59rem;
+    height: 28.75rem;
     position: relative;
     > * {
       position: absolute;
@@ -56,29 +59,9 @@ export const MainTodoCenter = styled.div`
   }
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
-    width: 100%;
-    height: 100%;
-    padding: 24rem 4rem 4rem 4rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr 0px;
-    box-sizing: border-box;
-    row-gap: 0;
-    > :nth-child(2) {
-      grid-column: 1 / span 2;
-    }
-    > :nth-child(1),
-    > :nth-child(3) {
-      margin-top: -12rem;
-      z-index: 5;
-      /* position: absolute;
-      bottom: 0; */
-    }
-    > :nth-child(1) {
-      justify-content: flex-start;
-    }
-    > :nth-child(3) {
-      justify-content: flex-end;
+    .center {
+      width: 89.9%;
+      height: calc(100vh - 13.25rem);
     }
   }
 `;

--- a/src/components/MainTodo/MainTodoStyles.tsx
+++ b/src/components/MainTodo/MainTodoStyles.tsx
@@ -33,6 +33,10 @@ export const MainTodoCenter = styled.div`
   width: 100%;
   .side-buttons {
     width: 59rem;
+    > div {
+      display: flex;
+      gap: 0.75rem;
+    }
   }
   .center {
     width: 59rem;
@@ -62,12 +66,26 @@ export const MainTodoCenter = styled.div`
   }
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
+    gap: 0.5rem;
     .center {
       width: 89.9%;
       height: calc(100vh - 13.25rem);
     }
     .side-buttons {
       width: 89.9%;
+      position: relative;
+    }
+    .time-setting {
+      position: absolute;
+      left: 1.25rem;
+      top: 3.5rem;
+      z-index: 5;
     }
   }
+`;
+
+export const CardWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
 `;

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -223,7 +223,15 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
         </CurrentMainCard>
       </CardWrapper>
     );
-  }, [currentCard, prevCard, isMobile, currentTodo, isLogin]);
+  }, [
+    currentCard,
+    prevCard,
+    isMobile,
+    currentTodo,
+    isLogin,
+    pomodoroSettings.focusStep,
+    pomodoroSettings.restStep,
+  ]);
 
   useEffect(() => {
     setTimeout(() => {

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -1,9 +1,11 @@
 import {
   ForwardedRef,
   forwardRef,
+  ReactNode,
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -11,6 +13,7 @@ import { SideButtons } from '../../molecules';
 import { CurrentTodoCard, NoTodoCard, RestCard } from '../../organisms';
 import { TodoList, AddTodo, PomodoroTimeSetting } from '..';
 import {
+  CardWrapper,
   MainTodoCenter,
   MainTodoContainer,
   MainTodoContentWrapper,
@@ -20,6 +23,7 @@ import {
   LoginContext,
   useCurrentTodo,
   useExtremeMode,
+  useIsMobile,
   usePomodoroActions,
   usePomodoroValue,
   useTimeMarker,
@@ -52,6 +56,7 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
   } = usePomodoroValue();
   const actions = usePomodoroActions();
   const { isLogin } = useContext(LoginContext);
+  const isMobile = useIsMobile();
   const { isExtreme } = useExtremeMode();
   const currentCardAnimationTriggerSubject = useRef(
     new Subject<
@@ -116,13 +121,36 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
     }
   };
 
+  const currentFocusedSideButton = useMemo(() => {
+    switch (currentCard) {
+      case 'addTodoModal':
+        return 'addTodo';
+      case 'timeModal':
+        return 'timer';
+      case 'todolistModal':
+        return 'list';
+      default:
+        return undefined;
+    }
+  }, [currentCard]);
+
   const CurrentMainCard = useCallback(
-    (props: { type: 'current' | 'prev' }) => {
+    (props: { type: 'current' | 'prev'; children?: ReactNode }) => {
       switch (props.type === 'current' ? currentCard : prevCard) {
         case 'addTodoModal':
-          return <AddTodo handleClose={handleClose} />;
+          return (
+            <AddTodo
+              mobileTopButtonSlot={props.children}
+              handleClose={handleClose}
+            />
+          );
         case 'timeModal':
-          return <PomodoroTimeSetting handleClose={handleClose} />;
+          return (
+            <PomodoroTimeSetting
+              mobileTopButtonSlot={props.children}
+              handleClose={handleClose}
+            />
+          );
         case 'todolistModal':
           return (
             <EditContextProvider>
@@ -131,27 +159,30 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
                 currentTodo={currentTodo}
                 focusStep={focusStep}
                 handleClose={handleClose}
+                mobileTopButtonSlot={props.children}
               />
             </EditContextProvider>
           );
         case 'rest':
           return currentTodo?.todo ? (
-            <RestCard />
+            <RestCard mobileTopButtonSlot={props.children} />
           ) : (
             <NoTodoCard
               addTodoHandler={() => {
                 handleClickSideButton('addTodoModal');
               }}
+              mobileTopButtonSlot={props.children}
             />
           );
         case 'currentTodo':
           return currentTodo?.todo ? (
-            <CurrentTodoCard />
+            <CurrentTodoCard mobileTopButtonSlot={props.children} />
           ) : (
             <NoTodoCard
               addTodoHandler={() => {
                 handleClickSideButton('addTodoModal');
               }}
+              mobileTopButtonSlot={props.children}
             />
           );
         default:
@@ -160,6 +191,39 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
     },
     [currentCard, prevCard, currentTodo, isLogin],
   );
+
+  const MainCard = useCallback(() => {
+    return (
+      <CardWrapper>
+        <CurrentMainCard type="current">
+          {isMobile && (
+            <SideButtons.ShowTimerButton
+              className="timer-mobile-btn"
+              focusStep={pomodoroSettings.focusStep}
+              restStep={pomodoroSettings.restStep}
+              theme={(() => {
+                if (isExtreme) {
+                  return 'extremeDarkBtn';
+                }
+                switch (currentCardColor) {
+                  case 'primary1':
+                    return 'darkBtn';
+                  case 'primary2':
+                    return 'lightBtn';
+                  case 'extreme_dark':
+                    return 'extremeLightBtn';
+                  case 'extreme_orange':
+                    return 'extremeDarkBtn';
+                  default:
+                    return 'darkBtn';
+                }
+              })()}
+            />
+          )}
+        </CurrentMainCard>
+      </CardWrapper>
+    );
+  }, [currentCard, prevCard, isMobile, currentTodo, isLogin]);
 
   useEffect(() => {
     setTimeout(() => {
@@ -206,89 +270,84 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
   }, [currentCard, pomodoroStatus, isExtreme]);
 
   return (
-    <MainTodoContainer ref={ref}>
-      <MainTodoContentWrapper>
-        <MainTodoCenter>
-          <div
-            className="side-buttons"
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-            }}
-          >
-            <SideButtons>
-              <SideButtons.SideButton
-                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
-                onClick={() => handleClickSideButton('timeModal')}
-              >
-                {isExtreme ? (
-                  <img src="icon/clock-red.svg" />
-                ) : (
-                  <img src="icon/clock.svg" />
-                )}
-                {pomodoroSettings.focusStep}분 집중 |{' '}
-                {pomodoroSettings.restStep}분 휴식
-              </SideButtons.SideButton>
-              <SideButtons.SideButton
-                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
-                onClick={() => handleClickSideButton('addTodoModal')}
-              >
-                Todo +
-              </SideButtons.SideButton>
-              <SideButtons.SideButton
-                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
-                onClick={() => handleClickSideButton('todolistModal')}
-              >
-                {/* TODO: 남은 할 일 계산 로직 추가 */}
-                {isExtreme ? (
-                  <img src="icon/list-red.svg" />
-                ) : (
-                  <img src="icon/list.svg" />
-                )}
-                남은 할일
-              </SideButtons.SideButton>
-            </SideButtons>
-            <SideButtons>
-              <SideButtons.SideButton
-                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
-                onClick={handleClose}
-              >
-                랭킹
-              </SideButtons.SideButton>
-              <SideButtons.SideButton
-                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
-                onClick={handleClose}
-                style={{
-                  width: '1.75rem',
-                  height: '1.75rem',
-                  padding: 0,
-                  textAlign: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                ?
-              </SideButtons.SideButton>
-            </SideButtons>
-          </div>
-          <div className="center">
-            <CardAnimationPlayerAtom
-              trigger={currentCardAnimationTrigger$.current}
+    <SideButtons
+      focusedButton={currentFocusedSideButton}
+      onClickHandlers={{
+        ranking: () => {
+          // handleClickSideButton('ranking');
+          throw new Error('Not implemented yet');
+        },
+        help: () => {
+          // handleClickSideButton('help');
+          throw new Error('Not implemented yet');
+        },
+        addTodo: () => {
+          handleClickSideButton('addTodoModal');
+        },
+        list: () => {
+          handleClickSideButton('todolistModal');
+        },
+        timer: () => {
+          handleClickSideButton('timeModal');
+        },
+        doAll: () => {
+          // handleClickSideButton('doAll');
+          throw new Error('Not implemented yet');
+        },
+      }}
+    >
+      <MainTodoContainer ref={ref}>
+        <MainTodoContentWrapper>
+          <MainTodoCenter>
+            <div
+              className="side-buttons"
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
             >
-              <CurrentMainCard type="current" />
-            </CardAnimationPlayerAtom>
-            {prevCard && (
-              <CardAnimationPlayerAtom animation={'HIDE_UP'}>
-                <CurrentMainCard type="prev" />
+              <div>
+                {!isMobile && (
+                  <SideButtons.ShowTimerButton
+                    focusStep={pomodoroSettings.focusStep}
+                    restStep={pomodoroSettings.restStep}
+                    theme={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                  />
+                )}
+                <SideButtons.ShowAddTodoButton
+                  theme={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                />
+                <SideButtons.ShowListButton
+                  theme={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                />
+              </div>
+              <div>
+                <SideButtons.ShowHelpButton
+                  theme={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                />
+              </div>
+            </div>
+            <div className="center">
+              <CardAnimationPlayerAtom
+                trigger={currentCardAnimationTrigger$.current}
+              >
+                <MainCard />
+                {/* <CurrentMainCard type="current" /> */}
               </CardAnimationPlayerAtom>
-            )}
-            {!prevCard && (
-              <CardAnimationPlayerAtom animation={'NEXT_UP'}>
-                <CardAtom bg={getDummyCardColor()} style={{ zIndex: -1 }} />
-              </CardAnimationPlayerAtom>
-            )}
-          </div>
-        </MainTodoCenter>
-      </MainTodoContentWrapper>
-    </MainTodoContainer>
+              {prevCard && (
+                <CardAnimationPlayerAtom animation={'HIDE_UP'}>
+                  <CurrentMainCard type="prev" />
+                </CardAnimationPlayerAtom>
+              )}
+              {!prevCard && (
+                <CardAnimationPlayerAtom animation={'NEXT_UP'}>
+                  <CardAtom bg={getDummyCardColor()} style={{ zIndex: -1 }} />
+                </CardAnimationPlayerAtom>
+              )}
+            </div>
+          </MainTodoCenter>
+        </MainTodoContentWrapper>
+      </MainTodoContainer>
+    </SideButtons>
   );
 });

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -282,7 +282,7 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
       focusedButton={currentFocusedSideButton}
       onClickHandlers={{
         ranking: () => alert('기능 준비 중입니다.'),
-        help:() => alert('기능 준비 중입니다.'),
+        help: () => alert('기능 준비 중입니다.'),
         addTodo: () => {
           handleClickSideButton('addTodoModal');
         },
@@ -292,7 +292,7 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
         timer: () => {
           handleClickSideButton('timeModal');
         },
-        doAll: () => alert('기능 준비 중입니다.'),,
+        doAll: () => alert('기능 준비 중입니다.'),
       }}
     >
       <MainTodoContainer ref={ref}>

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -281,14 +281,8 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
     <SideButtons
       focusedButton={currentFocusedSideButton}
       onClickHandlers={{
-        ranking: () => {
-          // handleClickSideButton('ranking');
-          throw new Error('Not implemented yet');
-        },
-        help: () => {
-          // handleClickSideButton('help');
-          throw new Error('Not implemented yet');
-        },
+        ranking: () => alert('기능 준비 중입니다.'),
+        help:() => alert('기능 준비 중입니다.'),
         addTodo: () => {
           handleClickSideButton('addTodoModal');
         },
@@ -298,10 +292,7 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
         timer: () => {
           handleClickSideButton('timeModal');
         },
-        doAll: () => {
-          // handleClickSideButton('doAll');
-          throw new Error('Not implemented yet');
-        },
+        doAll: () => alert('기능 준비 중입니다.'),,
       }}
     >
       <MainTodoContainer ref={ref}>

--- a/src/components/MainTodo/index.tsx
+++ b/src/components/MainTodo/index.tsx
@@ -209,48 +209,67 @@ export const MainTodo = forwardRef((_, ref: ForwardedRef<HTMLElement>) => {
     <MainTodoContainer ref={ref}>
       <MainTodoContentWrapper>
         <MainTodoCenter>
-          <SideButtons>
-            <SideButtons.SideButton
-              onClick={() => handleClickSideButton('timeModal')}
-            >
-              {isExtreme ? (
-                <img src="icon/clock-red.svg" />
-              ) : (
-                <img src="icon/clock.svg" />
-              )}
-              <TypoAtom
-                fontSize="body"
-                fontColor={isExtreme ? 'extreme_orange' : 'primary1'}
+          <div
+            className="side-buttons"
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <SideButtons>
+              <SideButtons.SideButton
+                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                onClick={() => handleClickSideButton('timeModal')}
               >
+                {isExtreme ? (
+                  <img src="icon/clock-red.svg" />
+                ) : (
+                  <img src="icon/clock.svg" />
+                )}
                 {pomodoroSettings.focusStep}분 집중 |{' '}
                 {pomodoroSettings.restStep}분 휴식
-              </TypoAtom>
-            </SideButtons.SideButton>
-
-            <SideButtons.SideButton
-              onClick={() => handleClickSideButton('todolistModal')}
-            >
-              {isExtreme ? (
-                <img src="icon/list-red.svg" />
-              ) : (
-                <img src="icon/list.svg" />
-              )}
-              {/* TODO: 남은 할 일 계산 로직 추가 */}
-              <TypoAtom
-                fontSize="body"
-                fontColor={isExtreme ? 'extreme_orange' : 'primary1'}
+              </SideButtons.SideButton>
+              <SideButtons.SideButton
+                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                onClick={() => handleClickSideButton('addTodoModal')}
               >
-                남은 할일
-              </TypoAtom>
-            </SideButtons.SideButton>
-            <SideButtons.SideButton
-              onClick={() => handleClickSideButton('addTodoModal')}
-            >
-              <div className={'tag-button' + (isExtreme ? ' extreme' : '')}>
                 Todo +
-              </div>
-            </SideButtons.SideButton>
-          </SideButtons>
+              </SideButtons.SideButton>
+              <SideButtons.SideButton
+                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                onClick={() => handleClickSideButton('todolistModal')}
+              >
+                {/* TODO: 남은 할 일 계산 로직 추가 */}
+                {isExtreme ? (
+                  <img src="icon/list-red.svg" />
+                ) : (
+                  <img src="icon/list.svg" />
+                )}
+                남은 할일
+              </SideButtons.SideButton>
+            </SideButtons>
+            <SideButtons>
+              <SideButtons.SideButton
+                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                onClick={handleClose}
+              >
+                랭킹
+              </SideButtons.SideButton>
+              <SideButtons.SideButton
+                btnStyle={isExtreme ? 'extremeLightBtn' : 'lightBtn'}
+                onClick={handleClose}
+                style={{
+                  width: '1.75rem',
+                  height: '1.75rem',
+                  padding: 0,
+                  textAlign: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                ?
+              </SideButtons.SideButton>
+            </SideButtons>
+          </div>
           <div className="center">
             <CardAnimationPlayerAtom
               trigger={currentCardAnimationTrigger$.current}

--- a/src/components/PomodoroTimeSetting.tsx
+++ b/src/components/PomodoroTimeSetting.tsx
@@ -309,7 +309,9 @@ const Rectangle = styled.div`
   margin-right: 0.375rem;
 `;
 
-const ClockTypo = styled(TypoAtom)`
+const ClockTypo = styled((props: React.ComponentProps<typeof TypoAtom>) => (
+  <TypoAtom {...props} />
+))`
   font-weight: 700;
   font-size: 8.75rem;
   line-height: 6.25rem;

--- a/src/components/PomodoroTimeSetting.tsx
+++ b/src/components/PomodoroTimeSetting.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { BtnAtom, CardAtom, TypoAtom } from '../atoms';
 
@@ -9,6 +9,7 @@ import {
   usePomodoroValue,
 } from '../hooks/usePomodoro';
 import styled from '@emotion/styled';
+import { useIsMobile } from '../hooks';
 
 interface ITimeCounterProps {
   timeTitle: string;
@@ -105,8 +106,10 @@ export const TimeSetter = ({
 
 export const PomodoroTimeSetting = ({
   handleClose,
+  mobileTopButtonSlot,
 }: {
   handleClose: () => void;
+  mobileTopButtonSlot?: ReactNode;
 }) => {
   /* pomodoro context */
   const {
@@ -121,6 +124,8 @@ export const PomodoroTimeSetting = ({
   const [restTimeIndex, setRestTimeIndex] = useState(
     restStepList.findIndex((time) => time === restStep),
   );
+
+  const isMobile = useIsMobile();
 
   /* local variable */
   const newTime = {
@@ -154,54 +159,88 @@ export const PomodoroTimeSetting = ({
 
   return (
     <PomodoroCardAtom bg="primary1">
-      <div>
-        <TimeSetter
-          timeTitle={'집중시간'}
-          time={focusStepList[focusTimeIndex]}
-          handleTimeUp={handleFocusUp}
-          handleTimeDown={handleFocusDown}
-        />
-        <TimeSetter
-          timeTitle={'휴식시간'}
-          time={restStepList[restTimeIndex]}
-          handleTimeUp={handleRestUp}
-          handleTimeDown={handleRestDown}
-        />
-      </div>
+      {isMobile && (
+        <div className="mobile-header-wrapper">
+          <div className="mobile-top-button-wrapper">{mobileTopButtonSlot}</div>
+          <BtnAtom handleOnClick={handleClose}>
+            <svg
+              width="2rem"
+              height="2rem"
+              viewBox="0 0 32 32"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className="svgBtn"
+            >
+              <rect
+                width="1.81331"
+                height="25.3864"
+                transform="matrix(-0.707107 0.707107 0.707107 0.707107 7.28223 6.19324)"
+                fill="#DBFE77"
+              />
+              <rect
+                x="7.28223"
+                y="25.233"
+                width="1.81331"
+                height="25.3864"
+                transform="rotate(-135 7.28223 25.233)"
+                fill="#DBFE77"
+              />
+            </svg>
+          </BtnAtom>
+        </div>
+      )}
+      <div className="time-setter-wrapper">
+        <div>
+          <TimeSetter
+            timeTitle={'집중시간'}
+            time={focusStepList[focusTimeIndex]}
+            handleTimeUp={handleFocusUp}
+            handleTimeDown={handleFocusDown}
+          />
+          <TimeSetter
+            timeTitle={'휴식시간'}
+            time={restStepList[restTimeIndex]}
+            handleTimeUp={handleRestUp}
+            handleTimeDown={handleRestDown}
+          />
+        </div>
 
-      <div>
-        <BtnAtom handleOnClick={handleSubmit} btnStyle="extremeDarkBtn">
-          <div style={{ paddingLeft: '2rem', paddingRight: '2rem' }}>
-            <TypoAtom fontColor="primary2" fontSize="b1">
-              저장
-            </TypoAtom>
-          </div>
-        </BtnAtom>
-        <BtnAtom handleOnClick={handleClose}>
-          <svg
-            width="2rem"
-            height="2rem"
-            viewBox="0 0 32 32"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="svgBtn"
-          >
-            <rect
-              width="1.81331"
-              height="25.3864"
-              transform="matrix(-0.707107 0.707107 0.707107 0.707107 7.28223 6.19324)"
-              fill="#DBFE77"
-            />
-            <rect
-              x="7.28223"
-              y="25.233"
-              width="1.81331"
-              height="25.3864"
-              transform="rotate(-135 7.28223 25.233)"
-              fill="#DBFE77"
-            />
-          </svg>
-        </BtnAtom>
+        <div>
+          <BtnAtom handleOnClick={handleSubmit} btnStyle="extremeDarkBtn">
+            <div style={{ paddingLeft: '2rem', paddingRight: '2rem' }}>
+              <TypoAtom fontColor="primary2" fontSize="b1">
+                저장
+              </TypoAtom>
+            </div>
+          </BtnAtom>
+          {!isMobile && (
+            <BtnAtom handleOnClick={handleClose}>
+              <svg
+                width="2rem"
+                height="2rem"
+                viewBox="0 0 32 32"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="svgBtn"
+              >
+                <rect
+                  width="1.81331"
+                  height="25.3864"
+                  transform="matrix(-0.707107 0.707107 0.707107 0.707107 7.28223 6.19324)"
+                  fill="#DBFE77"
+                />
+                <rect
+                  x="7.28223"
+                  y="25.233"
+                  width="1.81331"
+                  height="25.3864"
+                  transform="rotate(-135 7.28223 25.233)"
+                  fill="#DBFE77"
+                />
+              </svg>
+            </BtnAtom>
+          )}
+        </div>
       </div>
     </PomodoroCardAtom>
   );
@@ -209,8 +248,44 @@ export const PomodoroTimeSetting = ({
 
 const PomodoroCardAtom = styled(CardAtom)`
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: column;
+
+  .mobile-header-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .time-setter-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    & > div:first-of-type {
+      display: flex;
+      align-items: center;
+
+      & > div:first-of-type {
+        margin-right: 2rem;
+      }
+    }
+
+    & > div:last-of-type {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: flex-end;
+
+      & > button:first-of-type {
+        margin: auto;
+      }
+
+      & > button:last-of-type {
+        align-self: flex-start;
+      }
+    }
+  }
 
   .svgBtn path,
   .svgBtn rect {
@@ -220,29 +295,6 @@ const PomodoroCardAtom = styled(CardAtom)`
   .svgBtn:hover path,
   .svgBtn:hover rect {
     opacity: 0.4;
-  }
-
-  & > div:first-of-type {
-    display: flex;
-
-    & > div:first-of-type {
-      margin-right: 2rem;
-    }
-  }
-
-  & > div:last-of-type {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: flex-end;
-
-    & > button:first-of-type {
-      margin: auto;
-    }
-
-    & > button:last-of-type {
-      align-self: flex-start;
-    }
   }
 `;
 

--- a/src/components/TodoList/index.tsx
+++ b/src/components/TodoList/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, ReactNode, useCallback, useMemo } from 'react';
 
 /* component */
 import { TodoCard } from '../';
@@ -27,6 +27,7 @@ import {
   useEdit,
   type focusStep,
   useTouchSensor,
+  useIsMobile,
 } from '../../hooks';
 
 /* etc */
@@ -70,6 +71,7 @@ interface ITodoListProps {
   currentTodo: TodoEntity | undefined;
   focusStep: focusStep;
   handleClose: () => void;
+  mobileTopButtonSlot?: ReactNode;
 }
 
 export const TodoList = memo(
@@ -78,9 +80,12 @@ export const TodoList = memo(
     currentTodo,
     focusStep,
     handleClose,
+    mobileTopButtonSlot,
   }: ITodoListProps) => {
     /* api 호출 */
     const queryClient = useQueryClient();
+
+    const isMobile = useIsMobile();
 
     const { data: todos, isLoading: isTodoLoading } = useQuery(
       ['todos'],
@@ -154,42 +159,11 @@ export const TodoList = memo(
       <>
         {/* <BtnAtom children={'add Todo'} handleOnClick={onClickHandler} /> */}
         <TodoListContainer padding="1rem 1.5rem" className="card">
-          <ListSection>
-            <div className="header__todo">
-              <TypoAtom fontSize="body" fontColor="primary2">
-                완료한 TODO
-              </TypoAtom>
-            </div>
-            {doneTodoList ? (
-              <List>
-                {doneTodoList.map((doneTodo, idx) => (
-                  <MemoTodoCard
-                    isThisEdit={editTodoId === doneTodo.id}
-                    setEditTodoId={setEditTodoId}
-                    todoData={doneTodo}
-                    focusStep={focusStep}
-                    randomTagColor={randomTagColor}
-                    isCurrTodo={false}
-                    order={idx + 1}
-                  />
-                ))}
-              </List>
-            ) : (
-              <EmptyList>
-                <TypoAtom fontSize="body" fontColor="primary2">
-                  🍅
-                </TypoAtom>
-                <TypoAtom fontSize="body" fontColor="primary2">
-                  힘차게 시작해볼까요?
-                </TypoAtom>
-              </EmptyList>
-            )}
-          </ListSection>
-          <ListSection>
-            <div className="header__todo">
-              <TypoAtom fontSize="body" fontColor="primary2">
-                남은 TODO
-              </TypoAtom>
+          {isMobile && (
+            <div className="mobile-header-wrapper">
+              <div className="mobile-top-button-slot">
+                {mobileTopButtonSlot}
+              </div>
               <BtnAtom
                 handleOnClick={handleClose}
                 ariaLabel="close"
@@ -199,89 +173,145 @@ export const TodoList = memo(
                 <IconAtom size={1.5} alt="close" src="icon/closeYellow.svg" />
               </BtnAtom>
             </div>
-            {todoList ? (
-              <List>
-                {currentTodo && (
-                  <MemoTodoCard
-                    isThisEdit={editTodoId === currentTodo.id}
-                    setEditTodoId={setEditTodoId}
-                    todoData={currentTodo}
-                    focusStep={focusStep}
-                    randomTagColor={randomTagColor}
-                    isCurrTodo={true}
-                    order={(doneTodoList?.length ?? 0) + 1}
-                  />
+          )}
+          <div className="todo-list-wrapper">
+            <ListSection>
+              <div className="header__todo">
+                <TypoAtom fontSize="body" fontColor="primary2">
+                  완료한 TODO
+                </TypoAtom>
+              </div>
+              {doneTodoList ? (
+                <List>
+                  {doneTodoList.map((doneTodo, idx) => (
+                    <MemoTodoCard
+                      isThisEdit={editTodoId === doneTodo.id}
+                      setEditTodoId={setEditTodoId}
+                      todoData={doneTodo}
+                      focusStep={focusStep}
+                      randomTagColor={randomTagColor}
+                      isCurrTodo={false}
+                      order={idx + 1}
+                    />
+                  ))}
+                </List>
+              ) : (
+                <EmptyList>
+                  <TypoAtom fontSize="body" fontColor="primary2">
+                    🍅
+                  </TypoAtom>
+                  <TypoAtom fontSize="body" fontColor="primary2">
+                    힘차게 시작해볼까요?
+                  </TypoAtom>
+                </EmptyList>
+              )}
+            </ListSection>
+            <ListSection>
+              <div className="header__todo">
+                <TypoAtom fontSize="body" fontColor="primary2">
+                  남은 TODO
+                </TypoAtom>
+                {!isMobile && (
+                  <BtnAtom
+                    handleOnClick={handleClose}
+                    ariaLabel="close"
+                    className="close__btn"
+                    tabIndex={3}
+                  >
+                    <IconAtom
+                      size={1.5}
+                      alt="close"
+                      src="icon/closeYellow.svg"
+                    />
+                  </BtnAtom>
                 )}
-                <DragDropContext
-                  onDragEnd={handleDragEnd}
-                  enableDefaultSensors={false}
-                  sensors={[useMouseSensor, useTouchSensor]}
-                >
-                  <Droppable droppableId={droppableId}>
-                    {(provided) => (
-                      <div
-                        {...provided.droppableProps}
-                        ref={provided.innerRef}
-                        className="innerList"
-                      >
-                        {todoList.map(
-                          (todo, idx) =>
-                            todo.id !== currentTodo?.id && (
-                              <Draggable
-                                draggableId={String(todo.id)}
-                                index={idx}
-                                key={todo.id}
-                              >
-                                {optionalPortal((provided, snapshot) => (
-                                  <li
-                                    {...provided.draggableProps}
-                                    ref={provided.innerRef}
-                                  >
-                                    <MemoTodoCard
-                                      isThisEdit={editTodoId === todo.id}
-                                      setEditTodoId={setEditTodoId}
-                                      dragHandleProps={provided.dragHandleProps}
-                                      todoData={todo}
-                                      snapshot={snapshot}
-                                      focusStep={focusStep}
-                                      randomTagColor={randomTagColor}
-                                      isCurrTodo={
-                                        currentTodo
-                                          ? currentTodo.id === todo.id
-                                          : false
-                                      }
-                                      order={
-                                        idx +
-                                        1 +
-                                        (doneTodos ? doneTodos.size : 0)
-                                      }
-                                    />
-                                  </li>
-                                ))}
-                              </Draggable>
-                            ),
-                        )}
-                        {provided.placeholder}
-                      </div>
-                    )}
-                  </Droppable>
-                </DragDropContext>
-              </List>
-            ) : (
-              <EmptyList>
-                <BtnAtom
-                  handleOnClick={openAddTodoModal.bind(this, 'addTodoModal')}
-                  btnStyle="extremeDarkBtn"
-                >
-                  <div style={{ padding: '0.375rem 1.28125rem' }}>
-                    <TypoAtom fontSize="b1" fontColor="primary2">
-                      Todo+
-                    </TypoAtom>
-                  </div>
-                </BtnAtom>
-              </EmptyList>
-            )}
-          </ListSection>
+              </div>
+              {todoList ? (
+                <List>
+                  {currentTodo && (
+                    <MemoTodoCard
+                      isThisEdit={editTodoId === currentTodo.id}
+                      setEditTodoId={setEditTodoId}
+                      todoData={currentTodo}
+                      focusStep={focusStep}
+                      randomTagColor={randomTagColor}
+                      isCurrTodo={true}
+                      order={(doneTodoList?.length ?? 0) + 1}
+                    />
+                  )}
+                  <DragDropContext
+                    onDragEnd={handleDragEnd}
+                    enableDefaultSensors={false}
+                    sensors={[useMouseSensor, useTouchSensor]}
+                  >
+                    <Droppable droppableId={droppableId}>
+                      {(provided) => (
+                        <div
+                          {...provided.droppableProps}
+                          ref={provided.innerRef}
+                          className="innerList"
+                        >
+                          {todoList.map(
+                            (todo, idx) =>
+                              todo.id !== currentTodo?.id && (
+                                <Draggable
+                                  draggableId={String(todo.id)}
+                                  index={idx}
+                                  key={todo.id}
+                                >
+                                  {optionalPortal((provided, snapshot) => (
+                                    <li
+                                      {...provided.draggableProps}
+                                      ref={provided.innerRef}
+                                    >
+                                      <MemoTodoCard
+                                        isThisEdit={editTodoId === todo.id}
+                                        setEditTodoId={setEditTodoId}
+                                        dragHandleProps={
+                                          provided.dragHandleProps
+                                        }
+                                        todoData={todo}
+                                        snapshot={snapshot}
+                                        focusStep={focusStep}
+                                        randomTagColor={randomTagColor}
+                                        isCurrTodo={
+                                          currentTodo
+                                            ? currentTodo.id === todo.id
+                                            : false
+                                        }
+                                        order={
+                                          idx +
+                                          1 +
+                                          (doneTodos ? doneTodos.size : 0)
+                                        }
+                                      />
+                                    </li>
+                                  ))}
+                                </Draggable>
+                              ),
+                          )}
+                          {provided.placeholder}
+                        </div>
+                      )}
+                    </Droppable>
+                  </DragDropContext>
+                </List>
+              ) : (
+                <EmptyList>
+                  <BtnAtom
+                    handleOnClick={openAddTodoModal.bind(this, 'addTodoModal')}
+                    btnStyle="extremeDarkBtn"
+                  >
+                    <div style={{ padding: '0.375rem 1.28125rem' }}>
+                      <TypoAtom fontSize="b1" fontColor="primary2">
+                        Todo+
+                      </TypoAtom>
+                    </div>
+                  </BtnAtom>
+                </EmptyList>
+              )}
+            </ListSection>
+          </div>
         </TodoListContainer>
       </>
     );
@@ -295,8 +325,26 @@ const TodoListContainer = styled(CardAtom)`
   } */
   overflow: hidden;
   display: flex;
-  flex-direction: row;
-  column-gap: 1rem;
+  flex-direction: column;
+
+  .mobile-header-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .mobile-top-button-slot {
+    flex-shrink: 0;
+    text-align: left;
+  }
+
+  .todo-list-wrapper {
+    width: 100%;
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    column-gap: 1rem;
+  }
 
   background-color: ${({
     theme: {

--- a/src/components/TodoList/index.tsx
+++ b/src/components/TodoList/index.tsx
@@ -185,6 +185,7 @@ export const TodoList = memo(
                 <List>
                   {doneTodoList.map((doneTodo, idx) => (
                     <MemoTodoCard
+                      key={doneTodo.id}
                       isThisEdit={editTodoId === doneTodo.id}
                       setEditTodoId={setEditTodoId}
                       todoData={doneTodo}

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -80,22 +80,6 @@ export const useCurrentTodo = ({
   }, [todos]);
 
   useEffect(() => {
-    const subscription = PomodoroService.pomodoroStatus$.subscribe(
-      (changedStatus) => {
-        // 필요없어 보여서 주석처리
-        // if (currentTodo && changedStatus === PomodoroStatus.RESTING) {
-        //   currentTodo?.categories?.forEach((cantegory) => {
-        //     // timerApi.recordFocusTime(cantegory, time ?? 0);
-        //   });
-        // }
-      },
-    );
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, []);
-
-  useEffect(() => {
     status !== PomodoroStatus.OVERFOCUSING && checkIfCanRest();
     checkIfShouldFocus();
     const ifShouldRest = checkIfShouldRest();

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -79,11 +79,12 @@ export const useCurrentTodo = ({
   useEffect(() => {
     const subscription = PomodoroService.pomodoroStatus$.subscribe(
       (changedStatus) => {
-        if (currentTodo && changedStatus === PomodoroStatus.RESTING) {
-          currentTodo?.categories?.forEach((cantegory) => {
-            timerApi.recordFocusTime(cantegory, time ?? 0);
-          });
-        }
+        // 필요없어 보여서 주석처리
+        // if (currentTodo && changedStatus === PomodoroStatus.RESTING) {
+        //   currentTodo?.categories?.forEach((cantegory) => {
+        //     // timerApi.recordFocusTime(cantegory, time ?? 0);
+        //   });
+        // }
       },
     );
     return () => {

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -24,6 +24,7 @@ export const useCurrentTodo = ({
   const [focusedOnTodo, setFocusedOnTodo] = useState<number>(0);
   const [canRest, setCanRest] = useState(false);
   const [shouldFocus, setShouldFocus] = useState(false);
+  const [currentRound, setCurrentRound] = useState(1);
 
   const { data: todos } = useQuery<Map<string, TodoEntity[]>>(
     ['todos'],
@@ -53,6 +54,12 @@ export const useCurrentTodo = ({
       queryClient.invalidateQueries({ queryKey: ['doneTodos'] });
     },
   });
+
+  useEffect(() => {
+    setCurrentRound(
+      Math.ceil(focusedOnTodo / (pomodoroSettings.focusStep * pomodoroUnit)),
+    );
+  }, [focusedOnTodo, status]);
 
   useEffect(() => {
     const nextTodo = getNextTodo();
@@ -203,8 +210,17 @@ export const useCurrentTodo = ({
       focusedOnTodo,
       canRest,
       shouldFocus,
+      currentRound,
     }),
-    [doTodo, updateFocus, currentTodo, focusedOnTodo, canRest, shouldFocus],
+    [
+      doTodo,
+      updateFocus,
+      currentTodo,
+      focusedOnTodo,
+      canRest,
+      shouldFocus,
+      currentRound,
+    ],
   );
 
   return useCurrentTodoResult;

--- a/src/hooks/useCurrentTodo.ts
+++ b/src/hooks/useCurrentTodo.ts
@@ -57,9 +57,12 @@ export const useCurrentTodo = ({
 
   useEffect(() => {
     setCurrentRound(
-      Math.ceil(focusedOnTodo / (pomodoroSettings.focusStep * pomodoroUnit)),
+      Math.max(
+        Math.ceil(focusedOnTodo / (pomodoroSettings.focusStep * pomodoroUnit)),
+        1,
+      ),
     );
-  }, [focusedOnTodo, status]);
+  }, [focusedOnTodo, status, pomodoroSettings.focusStep]);
 
   useEffect(() => {
     const nextTodo = getNextTodo();

--- a/src/molecules/Clock.tsx
+++ b/src/molecules/Clock.tsx
@@ -74,15 +74,4 @@ const ClockContainer = styled.div<IClockProps>`
       }
     }
   }
-  @media ${({ theme }) => theme.responsiveDevice.mobile},
-    ${({ theme }) => theme.responsiveDevice.tablet_v} {
-    position: fixed;
-    top: 4rem;
-    .clock-date {
-      font-size: ${({ theme: { fontSize } }) => fontSize.h1.size};
-    }
-    .clock-time {
-      font-size: ${({ theme: { fontSize } }) => fontSize.clock.size};
-    }
-  }
 `;

--- a/src/molecules/ExtremeModeIndicator.tsx
+++ b/src/molecules/ExtremeModeIndicator.tsx
@@ -125,16 +125,4 @@ const ExtremeModeContainer = styled.div`
     width: 20px;
     height: 20px;
   }
-  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
-    ${({ theme }) => theme.responsiveDevice.mobile} {
-    margin-right: 8rem;
-    img {
-      width: 8rem;
-      height: 8rem;
-    }
-    .extreme-status {
-      width: fit-content;
-      word-break: break-all;
-    }
-  }
 `;

--- a/src/molecules/ExtremeModeIndicator.tsx
+++ b/src/molecules/ExtremeModeIndicator.tsx
@@ -87,14 +87,11 @@ export function ExtremeModeIndicator() {
 }
 
 const ExtremeModeContainer = styled.div`
-  position: absolute;
   z-index: 1;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  top: 2rem;
-  right: 2.0625rem;
-  gap: 9px;
+  width: fit-content;
   img {
     width: 1.5625rem;
     height: 2.5rem;

--- a/src/molecules/SideButtons.tsx
+++ b/src/molecules/SideButtons.tsx
@@ -1,59 +1,253 @@
-import { ReactNode } from 'react';
+import { createContext, ReactNode, useContext, useEffect } from 'react';
 import { IChildProps } from '../shared/interfaces';
-import styled from '@emotion/styled';
-import { BtnAtom } from '../atoms';
 import { SideBtnAtom } from '../atoms/SideBtnAtom';
 import { ButtonName } from '../styles/emotion';
+import { IconAtom } from '../atoms';
+import styled from '@emotion/styled';
 
-function SideButtonsMain({ children }: IChildProps) {
-  return <SideButtonsWrapper>{children}</SideButtonsWrapper>;
+export type SideButtonType =
+  | 'ranking'
+  | 'timer'
+  | 'addTodo'
+  | 'help'
+  | 'list'
+  | 'doAll';
+
+interface SideButtonContextValue {
+  onClickHandlers?: Record<SideButtonType, () => void>;
+  focusedButton?: SideButtonType;
 }
 
-const SideButtonsWrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 0.75rem;
-  button {
-    gap: 0.25rem;
-  }
-  @media ${({ theme }) => theme.responsiveDevice.tablet_v},
-    ${({ theme }) => theme.responsiveDevice.mobile} {
-    flex-direction: row;
-    justify-content: center;
-    &:first-child {
-      order: 1;
-    }
-    .icon {
-      width: 8rem;
-      height: 8rem;
-      border-radius: 8rem;
-      img {
-        width: 4rem;
-        height: 4rem;
-      }
-    }
-  }
-`;
+const SideButtonContext = createContext<SideButtonContextValue>({
+  onClickHandlers: {
+    ranking: () => {
+      throw new Error('onClickRanking not provided');
+    },
+    timer: () => {
+      throw new Error('onClickTimer not provided');
+    },
+    addTodo: () => {
+      throw new Error('onClickAddTodo not provided');
+    },
+    help: () => {
+      throw new Error('onClickHelp not provided');
+    },
+    list: () => {
+      throw new Error('onClickList not provided');
+    },
+    doAll: () => {
+      throw new Error('onClickDoAll not provided');
+    },
+  },
+});
 
-const SideButton = ({
-  onClick,
+function SideButtonsMain({
   children,
-  btnStyle = 'darkBtn',
-  style,
-}: {
-  onClick: () => void;
-  children?: ReactNode;
-  btnStyle?: ButtonName;
-  style?: React.CSSProperties;
-}) => {
+  ...props
+}: IChildProps & SideButtonContextValue) {
   return (
-    <SideBtnAtom onClick={onClick} btnStyle={btnStyle} style={style}>
+    <SideButtonContext.Provider
+      value={{
+        ...props,
+      }}
+    >
       {children}
+    </SideButtonContext.Provider>
+  );
+}
+
+const ShowAddTodoButton = ({ theme }: { theme: ButtonName }) => {
+  const context = useContext(SideButtonContext);
+  useEffect(() => {
+    console.log(context.focusedButton);
+  }, [context]);
+  return (
+    <SideBtnAtom
+      focused={context.focusedButton === 'addTodo'}
+      onClick={context.onClickHandlers?.addTodo}
+      btnStyle={theme}
+    >
+      Todo +
     </SideBtnAtom>
   );
 };
 
+const ShowTimerButton = ({
+  theme,
+  focusStep,
+  restStep,
+  className,
+}: {
+  theme: ButtonName;
+  focusStep: number;
+  restStep: number;
+  className?: string;
+}) => {
+  const context = useContext(SideButtonContext);
+  return (
+    <SideBtnAtom
+      focused={context.focusedButton === 'timer'}
+      onClick={context.onClickHandlers?.timer}
+      btnStyle={theme}
+      className={className}
+    >
+      {theme === 'extremeLightBtn' ? (
+        <SideBtnIcon
+          iconUrl="icon/clock-red.svg"
+          btnStyle={theme}
+          focused={context.focusedButton === 'timer'}
+        />
+      ) : (
+        <SideBtnIcon
+          iconUrl="icon/clock.svg"
+          btnStyle={theme}
+          focused={context.focusedButton === 'timer'}
+        />
+      )}
+      {focusStep}분 집중 | {restStep}분 휴식
+    </SideBtnAtom>
+  );
+};
+
+const ShowListButton = ({
+  theme,
+  className,
+}: {
+  theme: ButtonName;
+  className?: string;
+}) => {
+  const context = useContext(SideButtonContext);
+  return (
+    <SideBtnAtom
+      focused={context.focusedButton === 'list'}
+      onClick={context.onClickHandlers?.list}
+      btnStyle={theme}
+      className={className}
+    >
+      {theme === 'extremeLightBtn' ? (
+        <SideBtnIcon
+          iconUrl="icon/list-red.svg"
+          btnStyle={theme}
+          focused={context.focusedButton === 'list'}
+        />
+      ) : (
+        <SideBtnIcon
+          iconUrl="icon/list.svg"
+          btnStyle={theme}
+          focused={context.focusedButton === 'list'}
+        />
+      )}
+      남은 할일
+    </SideBtnAtom>
+  );
+};
+
+const ShowRankingButton = ({
+  theme,
+  className,
+}: {
+  theme: ButtonName;
+  className?: string;
+}) => {
+  const context = useContext(SideButtonContext);
+  return (
+    <SideBtnAtom
+      onClick={context.onClickHandlers?.ranking}
+      focused={context.focusedButton === 'ranking'}
+      btnStyle={theme}
+      className={className}
+    >
+      랭킹
+    </SideBtnAtom>
+  );
+};
+
+const ShowDoAllButton = ({
+  theme,
+  className,
+}: {
+  theme: ButtonName;
+  className?: string;
+}) => {
+  const context = useContext(SideButtonContext);
+  return (
+    <SideBtnAtom
+      focused={context.focusedButton === 'doAll'}
+      onClick={context.onClickHandlers?.doAll}
+      btnStyle={theme}
+      className={className}
+    >
+      전체완료
+    </SideBtnAtom>
+  );
+};
+
+const ShowHelpButton = ({
+  theme,
+  className,
+}: {
+  theme: ButtonName;
+  className?: string;
+}) => {
+  const context = useContext(SideButtonContext);
+  return (
+    <SideBtnAtom
+      onClick={context.onClickHandlers?.help}
+      focused={context.focusedButton === 'help'}
+      btnStyle={theme}
+      className={className}
+      style={{
+        width: '1.75rem',
+        height: '1.75rem',
+        padding: 0,
+        textAlign: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      ?
+    </SideBtnAtom>
+  );
+};
+
+const SideBtnIcon = styled.div<{
+  iconUrl: string;
+  btnStyle?: ButtonName;
+  focused?: boolean;
+}>`
+  width: 1.25rem;
+  height: 1.25rem;
+  mask-image: url(${({ iconUrl }) => iconUrl});
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  background-color: ${({ theme, btnStyle }) =>
+    theme.button[btnStyle ?? 'lightBtn'].default.color};
+  margin-right: 0.5rem;
+  &:hover {
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle ?? 'lightBtn'].hover.color};
+  }
+  &:active {
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle ?? 'lightBtn'].click.color};
+  }
+  &:disabled {
+    background-color: ${({ theme, btnStyle }) =>
+      theme.button[btnStyle ?? 'lightBtn'].default.color};
+    cursor: not-allowed;
+  }
+  ${({ focused, theme, btnStyle }) =>
+    focused &&
+    'background-color: ' +
+      theme.button[btnStyle ?? 'lightBtn'].click.color +
+      '!important;'}
+`;
+
 export const SideButtons = Object.assign(SideButtonsMain, {
-  SideButton,
+  ShowTimerButton,
+  ShowListButton,
+  ShowAddTodoButton,
+  ShowRankingButton,
+  ShowDoAllButton,
+  ShowHelpButton,
 });

--- a/src/molecules/SideButtons.tsx
+++ b/src/molecules/SideButtons.tsx
@@ -196,13 +196,7 @@ const ShowHelpButton = ({
       focused={context.focusedButton === 'help'}
       btnStyle={theme}
       className={className}
-      style={{
-        width: '1.75rem',
-        height: '1.75rem',
-        padding: 0,
-        textAlign: 'center',
-        justifyContent: 'center',
-      }}
+      btnType="icon"
     >
       ?
     </SideBtnAtom>

--- a/src/molecules/SideButtons.tsx
+++ b/src/molecules/SideButtons.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import { IChildProps } from '../shared/interfaces';
 import styled from '@emotion/styled';
 import { BtnAtom } from '../atoms';
+import { SideBtnAtom } from '../atoms/SideBtnAtom';
+import { ButtonName } from '../styles/emotion';
 
 function SideButtonsMain({ children }: IChildProps) {
   return <SideButtonsWrapper>{children}</SideButtonsWrapper>;
@@ -11,7 +13,7 @@ const SideButtonsWrapper = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
   button {
     gap: 0.25rem;
   }
@@ -37,14 +39,18 @@ const SideButtonsWrapper = styled.div`
 const SideButton = ({
   onClick,
   children,
+  btnStyle = 'darkBtn',
+  style,
 }: {
   onClick: () => void;
   children?: ReactNode;
+  btnStyle?: ButtonName;
+  style?: React.CSSProperties;
 }) => {
   return (
-    <BtnAtom btnStyle="textBtn" handleOnClick={onClick}>
+    <SideBtnAtom onClick={onClick} btnStyle={btnStyle} style={style}>
       {children}
-    </BtnAtom>
+    </SideBtnAtom>
   );
 };
 

--- a/src/molecules/SideButtons.tsx
+++ b/src/molecules/SideButtons.tsx
@@ -197,6 +197,8 @@ const ShowHelpButton = ({
       btnStyle={theme}
       className={className}
       btnType="icon"
+      type="button"
+      aria-label="도움말"
     >
       ?
     </SideBtnAtom>

--- a/src/molecules/SideButtons.tsx
+++ b/src/molecules/SideButtons.tsx
@@ -58,9 +58,7 @@ function SideButtonsMain({
 
 const ShowAddTodoButton = ({ theme }: { theme: ButtonName }) => {
   const context = useContext(SideButtonContext);
-  useEffect(() => {
-    console.log(context.focusedButton);
-  }, [context]);
+
   return (
     <SideBtnAtom
       focused={context.focusedButton === 'addTodo'}

--- a/src/organisms/CurrentTodo.tsx
+++ b/src/organisms/CurrentTodo.tsx
@@ -13,6 +13,7 @@ interface ICurrentTodoProps extends IChildProps {
   focusStep: number;
   focusedOnTodo: number;
   startResting: () => void;
+  currentRound: number;
 }
 
 export function CurrentTodo({
@@ -21,6 +22,7 @@ export function CurrentTodo({
   focusedOnTodo,
   doTodo,
   startResting,
+  currentRound,
 }: ICurrentTodoProps) {
   const [todoProgress, setTodoProgress] = useState<number>(0);
   const { isExtreme } = useExtremeMode();
@@ -28,8 +30,8 @@ export function CurrentTodo({
     setTodoProgress(
       Number(
         getPomodoroStepPercent({
-          curr: focusedOnTodo,
-          unit: todo.duration,
+          curr: focusedOnTodo % (focusStep * 60000),
+          unit: 1,
           step: focusStep,
         }),
       ),
@@ -46,39 +48,22 @@ export function CurrentTodo({
 
   return (
     <CurrentTodoContainer>
-      <TypoAtom fontSize={'h1'} fontColor={'primary2'} className="title">
-        {isExtreme ? '더 집중하셔야 합니다!' : '힘 내세요!'}
-      </TypoAtom>
-      <TypoAtom fontSize={'body'} fontColor={'primary2'} className="left-time">
-        남은 시간
-      </TypoAtom>
       <div className="center-container">
+        <TypoAtom
+          fontSize={'body'}
+          fontColor={'primary2'}
+          className="left-time"
+        >
+          남은 시간
+        </TypoAtom>
         <Clock ms={getLeftMs()} fontColor={'primary2'}></Clock>
-        <div className="todo-title">
-          <div className="categories">
-            <CategoryList categories={todo.categories}></CategoryList>
-          </div>
-          <TypoAtom fontSize={'h2'} fontColor="primary2">
-            {todo.todo}
-          </TypoAtom>
-        </div>
-      </div>
-      <div className="indicator-container">
-        <div className="todo-duration">
-          <TypoAtom fontSize={'h3'}>{todo.duration + ' Round'}</TypoAtom>
-          <TypoAtom fontSize="h3">
-            {todo.duration < 20
-              ? `🍅 `.repeat(todo.duration)
-              : `🍅 ` + todo.duration}
-          </TypoAtom>
-        </div>
         <div className="button-container">
           <BtnAtom
             className="rest"
             btnStyle="darkBtn"
             handleOnClick={() => startResting()}
           >
-            <IconAtom src="icon/pause-dark.svg" size={1} />
+            <IconAtom src="icon/pause-dark.svg" size={1.5} />
           </BtnAtom>
           <BtnAtom
             className="do-todo"
@@ -86,7 +71,7 @@ export function CurrentTodo({
             btnStyle="darkBtn"
             handleOnClick={() => doAndRest()}
           >
-            끝내기
+            <IconAtom src="icon/stop-dark.svg" size={1} />
           </BtnAtom>
         </div>
       </div>
@@ -95,9 +80,22 @@ export function CurrentTodo({
         <TodoProgressBarAtom
           type="primary2"
           progress={Math.min(todoProgress, 100)}
-        >
-          <div className="progress"></div>
-        </TodoProgressBarAtom>
+        ></TodoProgressBarAtom>
+      </div>
+
+      <div className="todo-title">
+        <div className="todo-duration">
+          <TypoAtom fontSize={'h3'}>{currentRound + ' Round'}</TypoAtom>
+          <div>
+            <TypoAtom fontSize="h3">{`🍅 `.repeat(currentRound)}</TypoAtom>
+            <TypoAtom fontSize="h3" className="left-round">
+              {`🍅 `.repeat(todo.duration - currentRound)}
+            </TypoAtom>
+          </div>
+        </div>
+        <TypoAtom fontSize={'h2'} fontColor="primary2">
+          {todo.todo}
+        </TypoAtom>
       </div>
     </CurrentTodoContainer>
   );
@@ -106,22 +104,30 @@ export function CurrentTodo({
 const CurrentTodoContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
   width: 100%;
   height: 100%;
+  position: relative;
+  gap: 2.56rem;
   .todo-title {
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
     max-width: 20ch;
+    position: absolute;
+    margin-bottom: 1.1428571429rem;
+    justify-content: flex-end;
+    align-items: center;
   }
   .center-container {
     display: flex;
     width: 100%;
     justify-content: space-between;
     align-items: center;
-    margin-top: 0.5rem;
+    > :first-child {
+      padding-left: 4.75rem;
+    }
   }
   .indicator-container {
     width: 100%;
@@ -135,16 +141,20 @@ const CurrentTodoContainer = styled.div`
     display: flex;
     gap: 0.5rem;
   }
-  .rest {
-    width: 2.25rem;
-    height: 2.25rem;
+  .rest,
+  .do-todo {
+    width: 3.75rem;
+    height: 3.75rem;
     display: flex;
     justify-content: center;
     align-items: center;
     img {
-      width: 1rem;
-      height: 1rem;
+      width: 1.5rem;
+      height: 1.5rem;
     }
+  }
+  .left-round {
+    opacity: 0.5;
   }
   .categories {
     width: 100%;
@@ -163,24 +173,7 @@ const CurrentTodoContainer = styled.div`
       color: ${({ theme }) => theme.color.primary.primary2};
     }
   }
-  .do-todo {
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    padding: 0.5rem 1.0625rem;
-    gap: 0.625rem;
-    width: 6.25rem;
-  }
-  .progress-container {
-    width: 100%;
-    height: 4rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.75rem;
-  }
+
   .title {
     line-height: 2.5rem;
     margin-bottom: 0.25rem;

--- a/src/organisms/CurrentTodo.tsx
+++ b/src/organisms/CurrentTodo.tsx
@@ -107,7 +107,7 @@ const CurrentTodoContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   width: 100%;
   height: 100%;
   .todo-title {

--- a/src/organisms/CurrentTodo.tsx
+++ b/src/organisms/CurrentTodo.tsx
@@ -54,6 +54,7 @@ export function CurrentTodo({
           className="rest"
           btnStyle="darkBtn"
           handleOnClick={() => startResting()}
+          ariaLabel="쉬기"
         >
           <IconAtom src="icon/pause-dark.svg" size={1.5} />
         </BtnAtom>
@@ -62,6 +63,7 @@ export function CurrentTodo({
           aria-label="do todo"
           btnStyle="darkBtn"
           handleOnClick={() => doAndRest()}
+          ariaLabel="할일완료"
         >
           <IconAtom src="icon/stop-dark.svg" size={1} />
         </BtnAtom>

--- a/src/organisms/CurrentTodo.tsx
+++ b/src/organisms/CurrentTodo.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BtnAtom, IconAtom, TodoProgressBarAtom, TypoAtom } from '../atoms';
 import { Clock, CategoryList } from '../molecules';
 import { TodoEntity } from '../DB/indexedAction';
-import { useExtremeMode } from '../hooks';
+import { useExtremeMode, useIsMobile } from '../hooks';
 import { IChildProps } from '../shared/interfaces';
 import { getPomodoroStepPercent } from '../shared/timeUtils';
 import styled from '@emotion/styled';
@@ -26,6 +26,7 @@ export function CurrentTodo({
 }: ICurrentTodoProps) {
   const [todoProgress, setTodoProgress] = useState<number>(0);
   const { isExtreme } = useExtremeMode();
+  const isMobile = useIsMobile();
   useEffect(() => {
     setTodoProgress(
       Number(
@@ -46,34 +47,37 @@ export function CurrentTodo({
     return todo.duration * focusStep * 60000 - focusedOnTodo;
   };
 
+  const getButtonContainer = useMemo(
+    () => (
+      <div className="button-container">
+        <BtnAtom
+          className="rest"
+          btnStyle="darkBtn"
+          handleOnClick={() => startResting()}
+        >
+          <IconAtom src="icon/pause-dark.svg" size={1.5} />
+        </BtnAtom>
+        <BtnAtom
+          className="do-todo"
+          aria-label="do todo"
+          btnStyle="darkBtn"
+          handleOnClick={() => doAndRest()}
+        >
+          <IconAtom src="icon/stop-dark.svg" size={1} />
+        </BtnAtom>
+      </div>
+    ),
+    [todo],
+  );
+
   return (
     <CurrentTodoContainer>
       <div className="center-container">
-        <TypoAtom
-          fontSize={'body'}
-          fontColor={'primary2'}
-          className="left-time"
-        >
+        <TypoAtom fontSize={'h3'} fontColor={'primary2'} className="left-time">
           남은 시간
         </TypoAtom>
         <Clock ms={getLeftMs()} fontColor={'primary2'}></Clock>
-        <div className="button-container">
-          <BtnAtom
-            className="rest"
-            btnStyle="darkBtn"
-            handleOnClick={() => startResting()}
-          >
-            <IconAtom src="icon/pause-dark.svg" size={1.5} />
-          </BtnAtom>
-          <BtnAtom
-            className="do-todo"
-            aria-label="do todo"
-            btnStyle="darkBtn"
-            handleOnClick={() => doAndRest()}
-          >
-            <IconAtom src="icon/stop-dark.svg" size={1} />
-          </BtnAtom>
-        </div>
+        {!isMobile && getButtonContainer}
       </div>
 
       <div className="progress-container">
@@ -89,13 +93,14 @@ export function CurrentTodo({
           <div>
             <TypoAtom fontSize="h3">{`🍅 `.repeat(currentRound)}</TypoAtom>
             <TypoAtom fontSize="h3" className="left-round">
-              {`🍅 `.repeat(todo.duration - currentRound)}
+              {`🍅 `.repeat(Math.max(todo.duration - currentRound, 0))}
             </TypoAtom>
           </div>
         </div>
         <TypoAtom fontSize={'h2'} fontColor="primary2">
           {todo.todo}
         </TypoAtom>
+        {isMobile && getButtonContainer}
       </div>
     </CurrentTodoContainer>
   );
@@ -106,7 +111,8 @@ const CurrentTodoContainer = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  width: 100%;
+  width: 90%;
+  max-width: 90%;
   height: 100%;
   position: relative;
   gap: 2.56rem;
@@ -114,7 +120,7 @@ const CurrentTodoContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    max-width: 20ch;
+    max-width: 40ch;
     position: absolute;
     margin-bottom: 1.1428571429rem;
     justify-content: flex-end;
@@ -123,11 +129,16 @@ const CurrentTodoContainer = styled.div`
   .center-container {
     display: flex;
     width: 100%;
+    margin-top: 1.125rem;
     justify-content: space-between;
     align-items: center;
     > :first-child {
       padding-left: 4.75rem;
     }
+  }
+  .progress-container {
+    width: 100%;
+    height: 11rem;
   }
   .indicator-container {
     width: 100%;
@@ -169,6 +180,9 @@ const CurrentTodoContainer = styled.div`
     justify-content: center;
     align-items: center;
     gap: 0.5rem;
+    > :first-child {
+      flex-shrink: 0;
+    }
     span {
       color: ${({ theme }) => theme.color.primary.primary2};
     }
@@ -182,62 +196,29 @@ const CurrentTodoContainer = styled.div`
     ${({ theme }) => theme.responsiveDevice.mobile} {
     height: 100%;
     position: relative;
-    .title {
-      font-size: ${({ theme: { fontSize } }) => fontSize.b1.size};
-      font-weight: ${({ theme: { fontSize } }) => fontSize.b1.weight};
-      text-align: right;
+    gap: 0rem;
+    justify-content: center;
+    .progress-container {
+      margin-top: 1.25rem;
+      height: 5.5rem;
+      margin-bottom: 0.625rem;
+    }
+    .center-container {
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      > :first-child {
+        padding-left: 0;
+      }
     }
     .todo-title {
-      overflow: auto;
-      padding-right: 16rem;
-      box-sizing: border-box;
-      max-height: 50%;
-      text-align: right;
-
-      span {
-        vertical-align: middle;
-        font-size: ${({ theme: { fontSize } }) => fontSize.h1.size};
-        white-space: normal;
-        overflow: initial;
-        text-align: right;
+      position: relative;
+      > :first-child {
+        margin-bottom: 1rem;
       }
     }
-    .categories {
-      margin: 4rem 0 4rem 0;
-      span {
-        font-size: ${({ theme: { fontSize } }) => fontSize.h1.size};
-        border-radius: 6rem;
-        padding: 1rem 3rem 1rem 3rem;
-      }
-    }
-    .todo-duration {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: flex-start;
-      gap: 2rem;
-      span {
-        font-size: ${({ theme: { fontSize } }) => fontSize.h1.size};
-      }
-      div > span {
-        font-size: ${({ theme: { fontSize } }) => fontSize.h1.size};
-        border-radius: 6rem;
-        padding: 0.5rem 3rem 0.5rem 3rem;
-      }
-    }
-    .progress-container {
-      position: absolute;
-      height: calc(100% - 12rem);
-      width: 6rem;
-      top: 0;
-      right: 0;
-      flex-direction: row-reverse;
-      box-sizing: border-box;
-      .do-todo {
-        position: absolute;
-        right: 8rem;
-        background-position: center;
-      }
+    .button-container {
+      margin-top: 3.75rem;
     }
   }
 `;

--- a/src/organisms/CurrentTodoCard.tsx
+++ b/src/organisms/CurrentTodoCard.tsx
@@ -51,22 +51,7 @@ export function CurrentTodoCard() {
 }
 
 const TransparentAbsoluteCardsParent = styled.div`
-  width: 53.75rem;
-  height: 20rem;
+  width: 100%;
+  height: 100%;
   position: relative;
-  .no-todo {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    button {
-      min-width: 101px;
-    }
-    > :first-child {
-      margin-bottom: 8px;
-    }
-    > :nth-child(2) {
-      margin-bottom: 12px;
-    }
-  }
 `;

--- a/src/organisms/CurrentTodoCard.tsx
+++ b/src/organisms/CurrentTodoCard.tsx
@@ -9,10 +9,14 @@ import {
   usePomodoroValue,
 } from '../hooks';
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { PomodoroStatus } from '../services/PomodoroService';
 
-export function CurrentTodoCard() {
+export function CurrentTodoCard({
+  mobileTopButtonSlot,
+}: {
+  mobileTopButtonSlot?: ReactNode;
+}) {
   const isMobile = useIsMobile();
   const { settings: pomodoroSettings, status, time } = usePomodoroValue();
   const { isExtreme } = useExtremeMode();
@@ -39,7 +43,17 @@ export function CurrentTodoCard() {
         padding={isMobile ? '0' : undefined}
         bg={isExtreme ? 'extreme_dark' : 'primary1'}
       >
-        <ExtremeModeIndicator />
+        {isMobile && (
+          <div className="mobile-header-wrapper">
+            <div className="mobile-top-button-slot">{mobileTopButtonSlot}</div>
+            <ExtremeModeIndicator />
+          </div>
+        )}
+        {!isMobile && (
+          <div className="desktop-extreme-wrapper">
+            <ExtremeModeIndicator />
+          </div>
+        )}
         {currentTodo.currentTodo && (
           <CurrentTodo
             todo={currentTodo.currentTodo}
@@ -61,4 +75,24 @@ const TransparentAbsoluteCardsParent = styled.div`
   width: 100%;
   height: 100%;
   position: relative;
+  .desktop-extreme-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    box-sizing: border-box;
+  }
+  .mobile-header-wrapper {
+    width: 100%;
+    padding: 1.25rem;
+    height: 1.75rem;
+    display: flex;
+    justify-content: space-between;
+    box-sizing: border-box;
+    align-items: flex-start;
+  }
+  .mobile-top-button-slot {
+    display: flex;
+    justify-content: flex-start;
+    height: fit-content;
+  }
 `;

--- a/src/organisms/CurrentTodoCard.tsx
+++ b/src/organisms/CurrentTodoCard.tsx
@@ -43,6 +43,7 @@ export function CurrentTodoCard() {
             focusStep={pomodoroSettings.focusStep}
             focusedOnTodo={currentTodo.focusedOnTodo}
             startResting={actions.startResting}
+            currentRound={currentTodo.currentRound}
           ></CurrentTodo>
         )}
       </CardAtom>

--- a/src/organisms/CurrentTodoCard.tsx
+++ b/src/organisms/CurrentTodoCard.tsx
@@ -4,6 +4,7 @@ import { CurrentTodo } from '../organisms';
 import {
   useCurrentTodo,
   useExtremeMode,
+  useIsMobile,
   usePomodoroActions,
   usePomodoroValue,
 } from '../hooks';
@@ -12,6 +13,7 @@ import { useEffect } from 'react';
 import { PomodoroStatus } from '../services/PomodoroService';
 
 export function CurrentTodoCard() {
+  const isMobile = useIsMobile();
   const { settings: pomodoroSettings, status, time } = usePomodoroValue();
   const { isExtreme } = useExtremeMode();
   const actions = usePomodoroActions();
@@ -32,7 +34,11 @@ export function CurrentTodoCard() {
 
   return (
     <TransparentAbsoluteCardsParent>
-      <CardAtom className="card" bg={isExtreme ? 'extreme_dark' : 'primary1'}>
+      <CardAtom
+        className="card"
+        padding={isMobile ? '0' : undefined}
+        bg={isExtreme ? 'extreme_dark' : 'primary1'}
+      >
         <ExtremeModeIndicator />
         {currentTodo.currentTodo && (
           <CurrentTodo

--- a/src/organisms/NoTodoCard.tsx
+++ b/src/organisms/NoTodoCard.tsx
@@ -1,27 +1,39 @@
 import styled from '@emotion/styled';
 import { BtnAtom, CardAtom, TypoAtom } from '../atoms';
+import { ReactNode } from 'react';
+import { useIsMobile } from '../hooks';
 
 interface INoTodoCardProps {
   addTodoHandler: () => void;
+  mobileTopButtonSlot?: ReactNode;
 }
 
-export function NoTodoCard({ addTodoHandler }: INoTodoCardProps) {
+export function NoTodoCard({
+  addTodoHandler,
+  mobileTopButtonSlot,
+}: INoTodoCardProps) {
+  const isMobile = useIsMobile();
   return (
     <StyledNoTodoCard>
-      <CardAtom bg="primary1" className="no-todo-card">
-        <TypoAtom fontSize="h3" className="tomato">
-          🍅
-        </TypoAtom>
-        <TypoAtom fontSize="h3" fontColor="primary2" className="caption">
-          새로운 TODO를 작성해볼까요?
-        </TypoAtom>
-        <BtnAtom
-          className="add-todo"
-          btnStyle="darkBtn"
-          handleOnClick={addTodoHandler}
-        >
-          Todo +
-        </BtnAtom>
+      <CardAtom bg="primary1" padding={'0'} className="no-todo-card">
+        {isMobile && (
+          <div className="mobile-top-button-wrapper">{mobileTopButtonSlot}</div>
+        )}
+        <div className="center-content">
+          <TypoAtom fontSize="h3" className="tomato">
+            🍅
+          </TypoAtom>
+          <TypoAtom fontSize="h3" fontColor="primary2" className="caption">
+            새로운 TODO를 작성해볼까요?
+          </TypoAtom>
+          <BtnAtom
+            className="add-todo"
+            btnStyle="darkBtn"
+            handleOnClick={addTodoHandler}
+          >
+            Todo +
+          </BtnAtom>
+        </div>
       </CardAtom>
     </StyledNoTodoCard>
   );
@@ -32,6 +44,24 @@ const StyledNoTodoCard = styled.div`
     display: flex;
     flex-direction: column;
     z-index: 1;
+    align-items: flex-start;
+    position: relative;
+    .mobile-top-button-wrapper {
+      flex-shrink: 0;
+      height: fit-content;
+      margin: 1.25rem;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+    .center-content {
+      width: 100%;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
     .tomato {
       margin-bottom: 8px;
     }

--- a/src/organisms/RestCard.tsx
+++ b/src/organisms/RestCard.tsx
@@ -4,8 +4,13 @@ import { Clock, ExtremeModeIndicator } from '../molecules';
 import { PomodoroStatus } from '../services/PomodoroService';
 import { usePomodoroActions, usePomodoroValue } from '../hooks/usePomodoro';
 import { useCurrentTodo, useExtremeMode, useIsMobile } from '../hooks';
+import { ReactNode } from 'react';
 
-export function RestCard() {
+export function RestCard({
+  mobileTopButtonSlot,
+}: {
+  mobileTopButtonSlot?: ReactNode;
+}) {
   const isMobile = useIsMobile();
   const pomodoro = usePomodoroValue();
   const actions = usePomodoroActions();
@@ -29,7 +34,19 @@ export function RestCard() {
     >
       {pomodoro.status === PomodoroStatus.RESTING && (
         <RestCardWrapper>
-          <ExtremeModeIndicator />
+          {isMobile && (
+            <div className="mobile-header-wrapper">
+              <div className="mobile-top-button-slot">
+                {mobileTopButtonSlot}
+              </div>
+              <ExtremeModeIndicator />
+            </div>
+          )}
+          {!isMobile && (
+            <div className="desktop-extreme-wrapper">
+              <ExtremeModeIndicator />
+            </div>
+          )}
           <div className="center-container">
             <TypoAtom
               fontSize={'h3'}
@@ -111,6 +128,17 @@ const RestCardWrapper = styled.div`
   justify-content: flex-end;
   width: 100%;
   height: 100%;
+  .mobile-header-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+  .desktop-extreme-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    box-sizing: border-box;
+  }
   .center-container {
     display: flex;
     align-items: center;

--- a/src/organisms/RestCard.tsx
+++ b/src/organisms/RestCard.tsx
@@ -3,9 +3,10 @@ import { BtnAtom, CardAtom, TodoProgressBarAtom, TypoAtom } from '../atoms';
 import { Clock, ExtremeModeIndicator } from '../molecules';
 import { PomodoroStatus } from '../services/PomodoroService';
 import { usePomodoroActions, usePomodoroValue } from '../hooks/usePomodoro';
-import { useCurrentTodo, useExtremeMode } from '../hooks';
+import { useCurrentTodo, useExtremeMode, useIsMobile } from '../hooks';
 
 export function RestCard() {
+  const isMobile = useIsMobile();
   const pomodoro = usePomodoroValue();
   const actions = usePomodoroActions();
   const { isExtreme } = useExtremeMode();
@@ -21,7 +22,11 @@ export function RestCard() {
     return pomodoro.settings.restStep * 60000 - (pomodoro.time ?? 0);
   };
   return (
-    <CardAtom className="card" bg={'primary2'}>
+    <CardAtom
+      className="card"
+      bg={'primary2'}
+      padding={isMobile ? '0' : undefined}
+    >
       {pomodoro.status === PomodoroStatus.RESTING && (
         <RestCardWrapper>
           <ExtremeModeIndicator />
@@ -130,5 +135,9 @@ const RestCardWrapper = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+  .progress-container {
+    width: 100%;
+    height: 11rem;
   }
 `;

--- a/src/shared/apis.ts
+++ b/src/shared/apis.ts
@@ -160,13 +160,6 @@ export const todosApi = {
 };
 export const timerApi = {
   _route: 'timer',
-  // duration in minutes
-  recordFocusTime: async (category: string, duration: number) => {
-    return baseApi.post(`${timerApi._route}/focused-time`, {
-      category,
-      duration,
-    });
-  },
   getRecords: async (
     timezoneOffset: number,
     unit: 'week' | 'month' | 'day',

--- a/src/styles/Global.tsx
+++ b/src/styles/Global.tsx
@@ -233,21 +233,13 @@ const style = css`
 
     /* 테블릿 가로 (해상도 768px ~ 1023px)*/
     @media all and (min-width: 768px) and (max-width: 1023px) {
-      font-size: 10px;
-      img {
-        width: 13px;
-        height: 13px;
-      }
+      font-size: 16px;
     }
 
     /* 모바일 가로 & 테블릿 세로 (해상도 480px ~ 767px)*/
     /* 모바일 세로 (해상도 ~ 479px)*/
     @media all and (max-width: 767px) {
-      font-size: 7px;
-      img {
-        width: 10px;
-        height: 10px;
-      }
+      font-size: 16px;
     }
   }
 

--- a/src/styles/cardAnimations.ts
+++ b/src/styles/cardAnimations.ts
@@ -15,7 +15,7 @@ export const CardAnimationStyle = css`
       left: -28.5px;
       top: -146.52px;
       z-index: 0;
-      opacity: 1;
+      opacity: 0;
       pointer-events: none;
     }
     100% {

--- a/src/styles/cardAnimations.ts
+++ b/src/styles/cardAnimations.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { designTheme } from './theme';
 
 export const CardAnimationStyle = css`
   @keyframes hideUp {
@@ -25,12 +26,17 @@ export const CardAnimationStyle = css`
 
   @keyframes showUp {
     0% {
-      transform: rotateZ(-3.65deg);
-      left: 34px;
-      top: 40px;
+      transform: rotateZ(-3deg);
+      left: 0px;
+      top: 2.27rem;
       z-index: 0;
       opacity: 1;
       pointer-events: none;
+      @media ${designTheme.responsiveDevice.tablet_v},
+        ${designTheme.responsiveDevice.mobile} {
+        top: 3.75rem;
+        transform: rotateZ(-3.65deg);
+      }
     }
     100% {
       transform: rotateZ(0);
@@ -52,12 +58,17 @@ export const CardAnimationStyle = css`
       pointer-events: none;
     }
     100% {
-      transform: rotateZ(3.65deg);
-      left: 17px;
-      top: 40px;
+      transform: rotateZ(3deg);
+      left: 0px;
+      top: 2.27rem;
       z-index: 0;
       opacity: 1;
       pointer-events: none;
+      @media ${designTheme.responsiveDevice.tablet_v},
+        ${designTheme.responsiveDevice.mobile} {
+        top: 3.75rem;
+        transform: rotateZ(3.65deg);
+      }
     }
   }
 `;

--- a/src/styles/cardAnimations.ts
+++ b/src/styles/cardAnimations.ts
@@ -32,11 +32,6 @@ export const CardAnimationStyle = css`
       z-index: 0;
       opacity: 1;
       pointer-events: none;
-      @media ${designTheme.responsiveDevice.tablet_v},
-        ${designTheme.responsiveDevice.mobile} {
-        top: 3.75rem;
-        transform: rotateZ(-3.65deg);
-      }
     }
     100% {
       transform: rotateZ(0);
@@ -45,6 +40,28 @@ export const CardAnimationStyle = css`
       z-index: 1;
       opacity: 1;
       pointer-events: auto;
+    }
+  }
+
+  @media ${designTheme.responsiveDevice.tablet_v},
+    ${designTheme.responsiveDevice.mobile} {
+    @keyframes showUp {
+      0% {
+        top: 3.75rem;
+        transform: rotateZ(-3.65deg);
+        left: 0px;
+        z-index: 0;
+        opacity: 1;
+        pointer-events: none;
+      }
+      100% {
+        transform: rotateZ(0);
+        left: 0;
+        top: 0;
+        z-index: 1;
+        opacity: 1;
+        pointer-events: auto;
+      }
     }
   }
 
@@ -68,6 +85,28 @@ export const CardAnimationStyle = css`
         ${designTheme.responsiveDevice.mobile} {
         top: 3.75rem;
         transform: rotateZ(3.65deg);
+      }
+    }
+  }
+
+  @media ${designTheme.responsiveDevice.tablet_v},
+    ${designTheme.responsiveDevice.mobile} {
+    @keyframes nextUp {
+      0% {
+        transform: rotateZ(10deg);
+        left: 28.5px;
+        top: 178px;
+        z-index: 0;
+        opacity: 0;
+        pointer-events: none;
+      }
+      100% {
+        transform: rotateZ(3.65deg);
+        left: 0px;
+        top: 3.75rem;
+        z-index: 0;
+        opacity: 1;
+        pointer-events: none;
       }
     }
   }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -131,7 +131,7 @@ export const designTheme: Theme = {
       },
       click: {
         backgroundColor: color.backgroundColor.extreme_dark,
-        color: color.fontColor.extreme_dark,
+        color: color.fontColor.extreme_orange,
       },
     },
     extremeDarkBtn: {


### PR DESCRIPTION
<img width="428" height="863" alt="Screenshot 2025-09-28 at 17 38 01" src="https://github.com/user-attachments/assets/f48300d4-ff35-4661-9ddb-21bb1f8aab5a" />

* 집중 화면에 대해 신규 디자인을 반영했습니다.
* 카드, SideButton에 대해 모바일 반응형 디자인을 적용했습니다.
* 카드 컨텐츠 (집중시간설정/투두목록) 는 적용되지 않았으므로 현재는 모바일에서 UI가 깨지는 상태입니다.
* SideButton 을 좀 더 제대로 된 CompoundComponent로 리팩토링 했습니다.
  * 히스토리 : 사이드버튼 일부가 모바일에서는 카드 내부로 들어가기 때문에 현 구조로는 구현이 번거로웠음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Mobile header slot added across add/edit screens, settings and list views for improved mobile controls.
  - Side buttons reorganized into dedicated actions (Add, Timer, List, Help, etc.) with a mobile timer button.
  - Current round shown with tomato icons; progress bar rebuilt as a responsive SVG component.

- Improvements
  - Refined card sizing, padding, responsive breakpoints, typography and animations; Extreme Mode indicator repositioned.

- Tests
  - Specs updated for emoji-based duration display and new props.

- Chores
  - Pre-push tests now run in CI mode; removed an unused focus-time API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->