### PR TITLE
모바일 AddTodo 수정

### DIFF
--- a/src/atoms/TomatoInputAtom.tsx
+++ b/src/atoms/TomatoInputAtom.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { formatTime } from '../shared/timeUtils';
 import styled from '@emotion/styled';
+import { useIsMobile } from '../hooks';
 
 interface ITomatoInputProps {
   max: number;
@@ -36,6 +37,7 @@ export const TomatoInputAtom = memo(
     const thumbRef = useRef<HTMLDivElement>(null);
     const tickRef = useRef<HTMLDivElement>(null);
     const tickCount = max - min;
+    const isMobile = useIsMobile();
 
     const handleDrag = (
       event: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>,
@@ -122,6 +124,7 @@ export const TomatoInputAtom = memo(
           onMouseUp={handleDrapEnd}
           onTouchEnd={handleDrapEnd}
           aria-label="slider"
+          isMobile={isMobile}
         >
           <Thumb
             ref={thumbRef}
@@ -149,7 +152,7 @@ export const TomatoInputAtom = memo(
           </InputTickWrapper>
         </RangeInputWrapper>
         {isLabel ? (
-          <LabelWrapper>
+          <LabelWrapper isMobile={isMobile}>
             {Array.from({ length: tickCount }).map((_, index) => (
               <TickWrapper key={index} aria-label="label">
                 {formatTime((index + 1) * period)}
@@ -162,11 +165,14 @@ export const TomatoInputAtom = memo(
   },
 );
 
-const RangeInputWrapper = styled.div`
+const RangeInputWrapper = styled.div<{ isMobile: boolean }>`
   position: relative;
   width: 100%;
   cursor: pointer;
   height: 20px;
+  & > * {
+    display: ${({ isMobile }) => (isMobile ? 'none' : 'block')};
+  }
 `;
 const AssistantLine = styled.div<{ isExtreme?: boolean }>`
   background-color: ${({
@@ -262,7 +268,8 @@ const Thumb = styled.div<{ useBalloon: boolean }>(({ theme, useBalloon }) => ({
   }),
 }));
 
-const LabelWrapper = styled.div`
+const LabelWrapper = styled.div<{ isMobile: boolean }>`
   display: flex;
   margin-top: 0.375rem;
+  display: ${({ isMobile }) => (isMobile ? 'none' : 'block')};
 `;

--- a/src/atoms/TomatoInputAtom.tsx
+++ b/src/atoms/TomatoInputAtom.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react';
 import { formatTime } from '../shared/timeUtils';
 import styled from '@emotion/styled';
-import { useIsMobile } from '../hooks';
 
 interface ITomatoInputProps {
   max: number;
@@ -37,7 +36,6 @@ export const TomatoInputAtom = memo(
     const thumbRef = useRef<HTMLDivElement>(null);
     const tickRef = useRef<HTMLDivElement>(null);
     const tickCount = max - min;
-    const isMobile = useIsMobile();
 
     const handleDrag = (
       event: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>,
@@ -124,7 +122,6 @@ export const TomatoInputAtom = memo(
           onMouseUp={handleDrapEnd}
           onTouchEnd={handleDrapEnd}
           aria-label="slider"
-          isMobile={isMobile}
         >
           <Thumb
             ref={thumbRef}
@@ -152,7 +149,7 @@ export const TomatoInputAtom = memo(
           </InputTickWrapper>
         </RangeInputWrapper>
         {isLabel ? (
-          <LabelWrapper isMobile={isMobile}>
+          <LabelWrapper>
             {Array.from({ length: tickCount }).map((_, index) => (
               <TickWrapper key={index} aria-label="label">
                 {formatTime((index + 1) * period)}
@@ -165,14 +162,11 @@ export const TomatoInputAtom = memo(
   },
 );
 
-const RangeInputWrapper = styled.div<{ isMobile: boolean }>`
+const RangeInputWrapper = styled.div`
   position: relative;
   width: 100%;
   cursor: pointer;
   height: 20px;
-  & > * {
-    display: ${({ isMobile }) => (isMobile ? 'none' : 'block')};
-  }
 `;
 const AssistantLine = styled.div<{ isExtreme?: boolean }>`
   background-color: ${({
@@ -268,8 +262,7 @@ const Thumb = styled.div<{ useBalloon: boolean }>(({ theme, useBalloon }) => ({
   }),
 }));
 
-const LabelWrapper = styled.div<{ isMobile: boolean }>`
+const LabelWrapper = styled.div`
   display: flex;
   margin-top: 0.375rem;
-  display: ${({ isMobile }) => (isMobile ? 'none' : 'block')};
 `;

--- a/src/atoms/TomatoInputAtom.tsx
+++ b/src/atoms/TomatoInputAtom.tsx
@@ -83,7 +83,7 @@ export const TomatoInputAtom = memo(
         }
         let posX = clientX - rangeInputRect.left;
         const count = Math.floor(posX / tickWidth);
-        handleTomato(count + 1);
+        handleTomato(count + min);
         posX = count * tickWidth - thumbWidth + halfTickWidth + halfThumbWidth;
         thumbRef.current.style.transform = 'translate(' + posX + 'px, -50%)';
       }
@@ -98,11 +98,11 @@ export const TomatoInputAtom = memo(
         const halfTickWidth = tickWidth / 2;
         const halfThumbWidth = thumbWidth / 2;
         const newCorrection =
-          tomato * tickWidth - halfTickWidth - halfThumbWidth;
+          (tomato - min + 1) * tickWidth - halfTickWidth - halfThumbWidth;
         thumbRef.current.style.transform =
           'translate(' + newCorrection + 'px, -50%)';
       }
-    }, [tomato]);
+    }, [tomato, min]);
 
     useEffect(() => {
       handleInitTomato();
@@ -133,13 +133,13 @@ export const TomatoInputAtom = memo(
           </Thumb>
           <AssistantLine isExtreme={isExtreme} />
           <InputTickWrapper>
-            {Array.from({ length: tickCount }).map((_, index) => (
+            {Array.from({ length: tickCount + 1 }).map((_, index) => (
               <TickWrapper key={index} ref={tickRef} aria-label="tick">
                 <InputTick
                   tabIndex={1}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter') {
-                      handleTomato(index + 1);
+                      handleTomato(index + min);
                     }
                   }}
                   isExtreme={isExtreme}
@@ -150,9 +150,9 @@ export const TomatoInputAtom = memo(
         </RangeInputWrapper>
         {isLabel ? (
           <LabelWrapper>
-            {Array.from({ length: tickCount }).map((_, index) => (
+            {Array.from({ length: tickCount + 1 }).map((_, index) => (
               <TickWrapper key={index} aria-label="label">
-                {formatTime((index + 1) * period)}
+                {formatTime((index + min) * period)}
               </TickWrapper>
             ))}
           </LabelWrapper>

--- a/src/atoms/TomatoInputAtom.tsx
+++ b/src/atoms/TomatoInputAtom.tsx
@@ -82,7 +82,7 @@ export const TomatoInputAtom = memo(
           clientX = (event as MouseEvent).clientX;
         }
         let posX = clientX - rangeInputRect.left;
-        const count = Math.floor(posX / tickWidth);
+        const count = Math.min(Math.max(Math.floor(posX / tickWidth), 0), tickCount);
         handleTomato(count + min);
         posX = count * tickWidth - thumbWidth + halfTickWidth + halfThumbWidth;
         thumbRef.current.style.transform = 'translate(' + posX + 'px, -50%)';
@@ -170,11 +170,11 @@ const RangeInputWrapper = styled.div`
 `;
 const AssistantLine = styled.div<{ isExtreme?: boolean }>`
   background-color: ${({
-    theme: {
-      color: { backgroundColor },
-    },
-    isExtreme,
-  }) => (isExtreme ? backgroundColor.extreme_dark : backgroundColor.primary1)};
+  theme: {
+    color: { backgroundColor },
+  },
+  isExtreme,
+}) => (isExtreme ? backgroundColor.extreme_dark : backgroundColor.primary1)};
   height: 0.25rem;
   border-radius: 50px;
   width: 100%;
@@ -204,11 +204,11 @@ const InputTick = styled.div<{ isExtreme?: boolean }>`
   width: 0.625rem;
   height: 0.625rem;
   background-color: ${({
-    theme: {
-      color: { backgroundColor },
-    },
-    isExtreme,
-  }) => (isExtreme ? backgroundColor.extreme_dark : backgroundColor.primary1)};
+  theme: {
+    color: { backgroundColor },
+  },
+  isExtreme,
+}) => (isExtreme ? backgroundColor.extreme_dark : backgroundColor.primary1)};
   border-radius: 50%;
 `;
 

--- a/src/atoms/TomatoSelectorAtom.tsx
+++ b/src/atoms/TomatoSelectorAtom.tsx
@@ -57,8 +57,8 @@ const TomatoSelectorAtom = ({
       </SelectedDisplay>
       {isOpen && (
         <OptionList isExtreme={isExtreme}>
-          {Array.from({ length: tickCount }).map((_, index) => {
-            const value = index + 1;
+          {Array.from({ length: tickCount + 1 }).map((_, index) => {
+            const value = min + index;
             const isSelected = value === tomato;
             return (
               <OptionItem

--- a/src/atoms/TomatoSelectorAtom.tsx
+++ b/src/atoms/TomatoSelectorAtom.tsx
@@ -53,7 +53,7 @@ const TomatoSelectorAtom = ({
         <SelectedValue>
           {tomato}회 ({formatTime(tomato * period)})
         </SelectedValue>
-        <ArrowIcon isOpen={isOpen}>▼</ArrowIcon>
+        <ArrowIcon isOpen={isOpen}>▲</ArrowIcon>
       </SelectedDisplay>
       {isOpen && (
         <OptionList isExtreme={isExtreme}>
@@ -112,7 +112,7 @@ const TomatoIcon = styled.span`
 const SelectedValue = styled.span`
   flex: 1;
   margin-left: 0.75rem;
-  font-size: ${({ theme }) => theme.fontSize.b1.size};
+  font-size: ${({ theme }) => theme.fontSize.body.size};
   font-weight: ${({ theme }) => theme.fontSize.b1.weight};
   color: ${({ theme }) => theme.color.fontColor.white};
 `;

--- a/src/atoms/TomatoSelectorAtom.tsx
+++ b/src/atoms/TomatoSelectorAtom.tsx
@@ -1,0 +1,193 @@
+import styled from '@emotion/styled';
+import { useState, useRef, useEffect } from 'react';
+import { formatTime } from '../shared/timeUtils';
+
+interface ITomatoSelectorProps {
+  max: number;
+  min: number;
+  period: number;
+  tomato: number;
+  handleTomato: (count: number) => void;
+  isExtreme?: boolean;
+}
+
+const TomatoSelectorAtom = ({
+  max,
+  min,
+  period,
+  tomato,
+  handleTomato,
+  isExtreme,
+}: ITomatoSelectorProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectorRef = useRef<HTMLDivElement>(null);
+  const tickCount = max - min;
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        selectorRef.current &&
+        !selectorRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (value: number) => {
+    handleTomato(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <SelectorWrapper ref={selectorRef}>
+      <SelectedDisplay
+        onClick={() => setIsOpen(!isOpen)}
+        isOpen={isOpen}
+        isExtreme={isExtreme}
+      >
+        <TomatoIcon>🍅</TomatoIcon>
+        <SelectedValue>
+          {tomato}회 ({formatTime(tomato * period)})
+        </SelectedValue>
+        <ArrowIcon isOpen={isOpen}>▼</ArrowIcon>
+      </SelectedDisplay>
+      {isOpen && (
+        <OptionList isExtreme={isExtreme}>
+          {Array.from({ length: tickCount }).map((_, index) => {
+            const value = index + 1;
+            const isSelected = value === tomato;
+            return (
+              <OptionItem
+                key={value}
+                onClick={() => handleSelect(value)}
+                isSelected={isSelected}
+                isExtreme={isExtreme}
+              >
+                <OptionTomato isSelected={isSelected}>🍅</OptionTomato>
+                <OptionText>
+                  {value}회 ({formatTime(value * period)})
+                </OptionText>
+              </OptionItem>
+            );
+          })}
+        </OptionList>
+      )}
+    </SelectorWrapper>
+  );
+};
+
+export { TomatoSelectorAtom };
+
+const SelectorWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const SelectedDisplay = styled.div<{ isOpen: boolean; isExtreme?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: ${({ isOpen }) => (isOpen ? '0 0 1rem 1rem' : '1rem')};
+  background-color: ${({ theme, isExtreme }) =>
+    isExtreme
+      ? theme.color.backgroundColor.light_extreme_dark
+      : theme.color.backgroundColor.dark_primary1};
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+
+const TomatoIcon = styled.span`
+  font-size: 1.5rem;
+`;
+
+const SelectedValue = styled.span`
+  flex: 1;
+  margin-left: 0.75rem;
+  font-size: ${({ theme }) => theme.fontSize.b1.size};
+  font-weight: ${({ theme }) => theme.fontSize.b1.weight};
+  color: ${({ theme }) => theme.color.fontColor.white};
+`;
+
+const ArrowIcon = styled.span<{ isOpen: boolean }>`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.color.fontColor.primary2};
+  transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+  transition: transform 0.2s ease;
+`;
+
+const OptionList = styled.div<{ isExtreme?: boolean }>`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  background-color: ${({ theme, isExtreme }) =>
+    isExtreme
+      ? theme.color.backgroundColor.extreme_dark
+      : theme.color.backgroundColor.primary1};
+  border-radius: 1rem 1rem 0 0;
+  z-index: 10;
+  box-shadow: ${({ theme }) => theme.shadow.tomato};
+
+  overscroll-behavior: contain;
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.color.fontColor.gray};
+    border-radius: 3px;
+  }
+`;
+
+const OptionItem = styled.div<{ isSelected: boolean; isExtreme?: boolean }>`
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  background-color: ${({ isSelected, theme, isExtreme }) =>
+    isSelected
+      ? isExtreme
+        ? theme.color.backgroundColor.light_extreme_dark
+        : theme.color.backgroundColor.dark_primary1
+      : 'transparent'};
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: ${({ theme, isExtreme }) =>
+      isExtreme
+        ? theme.color.backgroundColor.light_extreme_dark
+        : theme.color.backgroundColor.dark_primary1};
+  }
+
+  &:last-child {
+    border-radius: 0 0 1rem 1rem;
+  }
+`;
+
+const OptionTomato = styled.span<{ isSelected: boolean }>`
+  font-size: 1.25rem;
+  opacity: ${({ isSelected }) => (isSelected ? 1 : 0.6)};
+  transition: opacity 0.15s ease;
+`;
+
+const OptionText = styled.span`
+  margin-left: 0.75rem;
+  font-size: ${({ theme }) => theme.fontSize.b2.size};
+  font-weight: ${({ theme }) => theme.fontSize.b2.weight};
+  color: ${({ theme }) => theme.color.fontColor.white};
+`;

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -13,3 +13,4 @@ export { TagAtom, type ITagSpanProps } from './TagAtom';
 export { TodoProgressBarAtom } from './TodoProgressBarAtom';
 export { TomatoInputAtom } from './TomatoInputAtom';
 export { TypoAtom } from './TypoAtom';
+export { TomatoSelectorAtom } from './TomatoSelectorAtom';

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -406,7 +406,6 @@ const FooterWrapper = styled.div<{ isMobile: boolean }>`
     flex-direction: column;
     align-items: center;
     & > button {
-      width: 40%;
       min-width: 50%;
     }
   }

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -41,7 +41,6 @@ import styled from '@emotion/styled';
 import { ZodError } from 'zod';
 import FocusTrap from 'focus-trap-react';
 import { startOfYesterday } from 'date-fns';
-import { designTheme } from '../styles/theme';
 import { responsiveBreakpoints } from '../shared/constants';
 
 interface IAddTodoProps {
@@ -250,8 +249,8 @@ export const AddTodo = ({
                   borderColor: titleError
                     ? 'extreme_orange'
                     : isExtreme
-                    ? 'extreme_dark'
-                    : 'primary1',
+                      ? 'extreme_dark'
+                      : 'primary1',
                 }}
                 tabIndex={0}
               />
@@ -336,10 +335,10 @@ export const AddTodo = ({
 const AddTodoWrapper = styled(CardAtom.withComponent('form'))`
   overflow: visible;
   background-color: ${({
-    theme: {
-      color: { backgroundColor },
-    },
-  }) => backgroundColor.primary2};
+  theme: {
+    color: { backgroundColor },
+  },
+}) => backgroundColor.primary2};
   justify-content: space-between;
 
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -295,7 +295,7 @@ export const AddTodo = ({
           {isMobile ? (
             <TomatoSelectorAtom
               max={10}
-              min={0}
+              min={1}
               period={focusStep}
               handleTomato={handleTomato}
               tomato={tomato}
@@ -305,7 +305,7 @@ export const AddTodo = ({
             <TomatoContainer>
               <TomatoInputAtom
                 max={10}
-                min={0}
+                min={1}
                 period={focusStep}
                 handleTomato={handleTomato}
                 tomato={tomato}

--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -15,6 +15,7 @@ import {
   IconAtom,
   InputAtom,
   TomatoInputAtom,
+  TomatoSelectorAtom,
 } from '../atoms';
 import { CategoryInput } from '../molecules';
 
@@ -40,6 +41,8 @@ import styled from '@emotion/styled';
 import { ZodError } from 'zod';
 import FocusTrap from 'focus-trap-react';
 import { startOfYesterday } from 'date-fns';
+import { designTheme } from '../styles/theme';
+import { responsiveBreakpoints } from '../shared/constants';
 
 interface IAddTodoProps {
   handleClose: () => void;
@@ -242,7 +245,7 @@ export const AddTodo = ({
                   borderWidth: titleError ? '2px' : '1px',
                   width: '100%',
                   height: '3rem',
-                  font: 'h1',
+                  font: isMobile ? 'h3' : 'h1',
                   fontColor: isExtreme ? 'extreme_dark' : 'primary1',
                   borderColor: titleError
                     ? 'extreme_orange'
@@ -288,9 +291,9 @@ export const AddTodo = ({
             )}
           </CategoryWrapper>
         </MainWrapper>
-        <FooterWrapper>
-          <TomatoContainer>
-            <TomatoInputAtom
+        <FooterWrapper isMobile={isMobile}>
+          {isMobile ? (
+            <TomatoSelectorAtom
               max={10}
               min={0}
               period={focusStep}
@@ -298,7 +301,19 @@ export const AddTodo = ({
               tomato={tomato}
               isExtreme={isExtreme}
             />
-          </TomatoContainer>
+          ) : (
+            <TomatoContainer>
+              <TomatoInputAtom
+                max={10}
+                min={0}
+                period={focusStep}
+                handleTomato={handleTomato}
+                tomato={tomato}
+                isExtreme={isExtreme}
+              />
+            </TomatoContainer>
+          )}
+
           <BtnAtom
             paddingHorizontal="2.0625rem"
             paddingVertical="0.375rem"
@@ -329,9 +344,6 @@ const AddTodoWrapper = styled(CardAtom.withComponent('form'))`
 
   @media ${({ theme }) => theme.responsiveDevice.tablet_v},
     ${({ theme }) => theme.responsiveDevice.mobile} {
-    .todoTitle {
-      margin-bottom: 2rem;
-    }
     .calendar {
       margin: 2rem 0;
     }
@@ -385,8 +397,18 @@ const TomatoContainer = styled.div`
   width: 100%;
 `;
 
-const FooterWrapper = styled.div`
+const FooterWrapper = styled.div<{ isMobile: boolean }>`
   display: flex;
+  /* flex-direction: ${({ isMobile }) => (isMobile ? 'column' : 'row')}; */
   width: 100%;
   column-gap: 1.5625rem;
+  @media all and (max-width: ${responsiveBreakpoints.tablet_v.max}px) {
+    row-gap: 30px;
+    flex-direction: column;
+    align-items: center;
+    & > button {
+      width: 40%;
+      min-width: 50%;
+    }
+  }
 `;

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -10,7 +10,6 @@ export const useIsMobile = () => {
     setResponsiveMobile(responsiveMobileRef.current);
   };
 
-
   useEffect(() => {
     if (window.ResizeObserver)
       new ResizeObserver((entries) => {


### PR DESCRIPTION
<img width="316" height="835" alt="image" src="https://github.com/user-attachments/assets/d80a7759-d1b4-420f-b68d-ccf002de57b9" />

- TomatoSelector 추가
- AddTodo의 mobile UI 수정
  - TomatoSelector 추가 및 isMobile기반 분기처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tomato selector dropdown component for choosing tomato durations.
  * Add-todo form now shows the selector on mobile, with responsive layout adjustments.

* **Bug Fixes**
  * Fixed indexing and initialization logic in tomato input to ensure accurate selection and labels.

* **Style**
  * Improved responsive layout and typography for smaller screens; footer layout adjusted for mobile.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->